### PR TITLE
Add OAuth 2.0 authentication flow and SSL verification toggle

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,6 +45,7 @@
 - [x] Binary body support
 - [x] GraphQL mode with query/variables editor and schema introspection
 - [x] OAuth 2.0 authentication flow (authorization code, client credentials)
+- [x] SSL certificate verification toggle (disable per-request, like Postman's "SSL verification" setting)
 - [ ] Pre-request scripts (JavaScript, runs before send)
 - [ ] Post-response tests (assertions on status, body, headers)
 - [ ] Request chaining -- use values from one response in the next request

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,7 +44,7 @@
 - [x] File upload support in Form Data body type
 - [x] Binary body support
 - [x] GraphQL mode with query/variables editor and schema introspection
-- [ ] OAuth 2.0 authentication flow (authorization code, client credentials)
+- [x] OAuth 2.0 authentication flow (authorization code, client credentials)
 - [ ] Pre-request scripts (JavaScript, runs before send)
 - [ ] Post-response tests (assertions on status, body, headers)
 - [ ] Request chaining -- use values from one response in the next request

--- a/server/__tests__/proxy.test.js
+++ b/server/__tests__/proxy.test.js
@@ -84,3 +84,25 @@ describe('Proxy Server', () => {
     expect(Array.isArray(res.body.cookies)).toBe(true);
   });
 });
+
+describe('OAuth Token Endpoint', () => {
+  it('returns 400 when tokenUrl is missing', async () => {
+    const res = await request.post('/api/oauth/token').send({
+      grantType: 'client_credentials',
+      clientId: 'id',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Token URL is required');
+  });
+
+  it('returns error for unreachable token URL', async () => {
+    const res = await request.post('/api/oauth/token').send({
+      tokenUrl: 'http://localhost:99999/token',
+      grantType: 'client_credentials',
+      clientId: 'id',
+      clientSecret: 'secret',
+    });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBeDefined();
+  });
+});

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -168,11 +168,17 @@ app.post('/api/oauth/token', async (req, res) => {
   if (!tokenUrl) {
     return res.status(400).json({ error: 'Token URL is required' });
   }
+  if (!grantType) {
+    return res.status(400).json({ error: 'Grant type is required' });
+  }
+  if (!clientId) {
+    return res.status(400).json({ error: 'Client ID is required' });
+  }
 
   try {
     const params = new URLSearchParams();
     params.append('grant_type', grantType);
-    params.append('client_id', clientId || '');
+    params.append('client_id', clientId);
 
     if (clientSecret) {
       params.append('client_secret', clientSecret);

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -200,11 +200,17 @@ app.post('/api/oauth/token', async (req, res) => {
     });
 
     const text = await response.text();
+    const contentType = response.headers.get('content-type') || '';
     let data;
     try {
       data = JSON.parse(text);
     } catch {
-      data = { error: 'Invalid response from token endpoint', raw: text };
+      // Some providers (e.g. older GitHub) return form-encoded token responses
+      if (contentType.includes('application/x-www-form-urlencoded') || text.includes('access_token=')) {
+        data = Object.fromEntries(new URLSearchParams(text));
+      } else {
+        data = { error: 'Invalid response from token endpoint', raw: text };
+      }
     }
 
     res.status(response.status).json(data);

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import crypto from 'crypto';
+import { Agent } from 'undici';
 
 const app = express();
 const PORT = 3001;
@@ -45,7 +46,7 @@ function buildMultipartBody(entries) {
 }
 
 app.post('/api/proxy', async (req, res) => {
-  const { method, url, headers, body, bodyType, formDataEntries, binary } = req.body;
+  const { method, url, headers, body, bodyType, formDataEntries, binary, sslVerification } = req.body;
 
   if (!url) {
     return res.status(400).json({ error: 'URL is required' });
@@ -84,6 +85,11 @@ app.post('/api/proxy', async (req, res) => {
       } else if (body) {
         fetchOptions.body = JSON.stringify(body);
       }
+    }
+
+    // When SSL verification is disabled, use a custom undici Agent that skips cert checks
+    if (sslVerification === false) {
+      fetchOptions.dispatcher = new Agent({ connect: { rejectUnauthorized: false } });
     }
 
     const startTime = Date.now();

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -158,6 +158,58 @@ app.post('/api/proxy', async (req, res) => {
   }
 });
 
+/**
+ * OAuth 2.0 token exchange endpoint.
+ * Handles both authorization_code and client_credentials grant types.
+ */
+app.post('/api/oauth/token', async (req, res) => {
+  const { tokenUrl, grantType, clientId, clientSecret, code, redirectUri, scope } = req.body;
+
+  if (!tokenUrl) {
+    return res.status(400).json({ error: 'Token URL is required' });
+  }
+
+  try {
+    const params = new URLSearchParams();
+    params.append('grant_type', grantType);
+    params.append('client_id', clientId || '');
+
+    if (clientSecret) {
+      params.append('client_secret', clientSecret);
+    }
+
+    if (grantType === 'authorization_code') {
+      if (code) params.append('code', code);
+      if (redirectUri) params.append('redirect_uri', redirectUri);
+    }
+
+    if (scope) {
+      params.append('scope', scope);
+    }
+
+    const response = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: 'Invalid response from token endpoint', raw: text };
+    }
+
+    res.status(response.status).json(data);
+  } catch (error) {
+    const cause = error.cause || error;
+    res.status(500).json({
+      error: cause.message || error.message || 'Token exchange failed',
+    });
+  }
+});
+
 // Export app for testing
 export { app };
 

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -169,7 +169,7 @@ app.post('/api/proxy', async (req, res) => {
  * Handles both authorization_code and client_credentials grant types.
  */
 app.post('/api/oauth/token', async (req, res) => {
-  const { tokenUrl, grantType, clientId, clientSecret, code, redirectUri, scope } = req.body;
+  const { tokenUrl, grantType, clientId, clientSecret, code, redirectUri, scope, sslVerification, clientAuthMethod } = req.body;
 
   if (!tokenUrl) {
     return res.status(400).json({ error: 'Token URL is required' });
@@ -184,10 +184,19 @@ app.post('/api/oauth/token', async (req, res) => {
   try {
     const params = new URLSearchParams();
     params.append('grant_type', grantType);
-    params.append('client_id', clientId);
 
-    if (clientSecret) {
-      params.append('client_secret', clientSecret);
+    const fetchHeaders = { 'Content-Type': 'application/x-www-form-urlencoded' };
+
+    if (clientAuthMethod === 'basic' && clientSecret) {
+      // client_secret_basic: send credentials via Authorization header
+      const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+      fetchHeaders['Authorization'] = `Basic ${credentials}`;
+    } else {
+      // client_secret_post (default): send credentials in body
+      params.append('client_id', clientId);
+      if (clientSecret) {
+        params.append('client_secret', clientSecret);
+      }
     }
 
     if (grantType === 'authorization_code') {
@@ -199,11 +208,17 @@ app.post('/api/oauth/token', async (req, res) => {
       params.append('scope', scope);
     }
 
-    const response = await fetch(tokenUrl, {
+    const fetchOptions = {
       method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      headers: fetchHeaders,
       body: params.toString(),
-    });
+    };
+
+    if (sslVerification === false) {
+      fetchOptions.dispatcher = new Agent({ connect: { rejectUnauthorized: false } });
+    }
+
+    const response = await fetch(tokenUrl, fetchOptions);
 
     const text = await response.text();
     const contentType = response.headers.get('content-type') || '';

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -463,6 +463,23 @@ function AuthEditor({ request }: { request: RequestConfig }) {
             />
           </label>
 
+          {/* Client Auth Method */}
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-dark-300 font-medium">Client Authentication</span>
+            <select
+              value={request.auth.oauth2?.clientAuthMethod || 'post'}
+              onChange={e =>
+                updateAuth({
+                  oauth2: { ...defaultOAuth2Config(), ...request.auth.oauth2, clientAuthMethod: e.target.value as 'post' | 'basic' },
+                })
+              }
+              className="bg-dark-700 border border-dark-600 rounded-lg px-3 py-2 text-sm text-dark-100 cursor-pointer"
+            >
+              <option value="post">Send in body (client_secret_post)</option>
+              <option value="basic">Send as Basic Auth header (client_secret_basic)</option>
+            </select>
+          </label>
+
           {/* Scope */}
           <label className="flex flex-col gap-1">
             <span className="text-xs text-dark-300 font-medium">Scope</span>
@@ -569,6 +586,7 @@ function AuthEditor({ request }: { request: RequestConfig }) {
                   const token = await fetchOAuth2Token(
                     cfg,
                     cfg.grantType === 'authorization_code' ? authCode : undefined,
+                    request.sslVerification,
                   );
                   updateAuth({ oauth2: { ...raw, token } });
                   setAuthCode('');

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -589,7 +589,7 @@ function AuthEditor({ request }: { request: RequestConfig }) {
               {tokenLoading
                 ? 'Requesting...'
                 : request.auth.oauth2?.token?.accessToken
-                  ? 'Refresh Token'
+                  ? 'Get New Token'
                   : 'Get Token'}
             </button>
             {request.auth.oauth2?.token?.accessToken && (

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -532,7 +532,9 @@ function AuthEditor({ request }: { request: RequestConfig }) {
                   : 'Token active'}
               </span>
               <span className="text-xs text-dark-400 font-mono ml-auto truncate max-w-[200px]">
-                {request.auth.oauth2.token.accessToken.substring(0, 20)}...
+                {request.auth.oauth2.token.accessToken.length > 20
+                  ? `${request.auth.oauth2.token.accessToken.substring(0, 20)}...`
+                  : request.auth.oauth2.token.accessToken}
               </span>
             </div>
           )}

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
 import { xml } from '@codemirror/lang-xml';
@@ -216,6 +216,13 @@ function AuthEditor({ request }: { request: RequestConfig }) {
   const [tokenLoading, setTokenLoading] = useState(false);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const [authCode, setAuthCode] = useState('');
+
+  // Reset transient OAuth state when switching between requests
+  useEffect(() => {
+    setTokenError(null);
+    setAuthCode('');
+    setTokenLoading(false);
+  }, [request.id]);
 
   const authTypes: { id: AuthType; label: string }[] = [
     { id: 'none', label: 'No Auth' },

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -4,13 +4,14 @@ import { json } from '@codemirror/lang-json';
 import { xml } from '@codemirror/lang-xml';
 import { html } from '@codemirror/lang-html';
 import { oneDark } from '@codemirror/theme-one-dark';
-import type { RequestConfig, BodyType, AuthType } from '../types';
+import type { RequestConfig, BodyType, AuthType, OAuth2GrantType } from '../types';
 import { useAppStore } from '../store';
 import type { Theme } from '../store';
 import { KeyValueEditor } from './KeyValueEditor';
 import { FormDataEditor } from './FormDataEditor';
 import { BinaryBodyEditor } from './BinaryBodyEditor';
 import { GraphQLEditor } from './GraphQLEditor';
+import { fetchOAuth2Token, buildAuthorizationUrl, isTokenExpired } from '../utils/oauth';
 
 type RequestTabType = 'params' | 'headers' | 'body' | 'auth';
 
@@ -210,11 +211,16 @@ function BodyEditor({ request }: { request: RequestConfig }) {
 function AuthEditor({ request }: { request: RequestConfig }) {
   const updateRequest = useAppStore(s => s.updateRequest);
 
+  const [tokenLoading, setTokenLoading] = useState(false);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+  const [authCode, setAuthCode] = useState('');
+
   const authTypes: { id: AuthType; label: string }[] = [
     { id: 'none', label: 'No Auth' },
     { id: 'basic', label: 'Basic Auth' },
     { id: 'bearer', label: 'Bearer Token' },
     { id: 'api-key', label: 'API Key' },
+    { id: 'oauth2', label: 'OAuth 2.0' },
   ];
 
   const updateAuth = (updates: Partial<RequestConfig['auth']>) => {
@@ -354,6 +360,246 @@ function AuthEditor({ request }: { request: RequestConfig }) {
           </label>
         </div>
       )}
+
+      {request.auth.type === 'oauth2' && (
+        <div className="flex flex-col gap-3 max-w-lg">
+          {/* Grant type selector */}
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-dark-300 font-medium">Grant Type</span>
+            <select
+              value={request.auth.oauth2?.grantType || 'client_credentials'}
+              onChange={e =>
+                updateAuth({
+                  oauth2: {
+                    ...defaultOAuth2Config(),
+                    ...request.auth.oauth2,
+                    grantType: e.target.value as OAuth2GrantType,
+                  },
+                })
+              }
+              className="bg-dark-700 border border-dark-600 rounded-lg px-3 py-2 text-sm text-dark-100 cursor-pointer"
+            >
+              <option value="client_credentials">Client Credentials</option>
+              <option value="authorization_code">Authorization Code</option>
+            </select>
+          </label>
+
+          {/* Authorization URL (only for auth code flow) */}
+          {request.auth.oauth2?.grantType === 'authorization_code' && (
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-dark-300 font-medium">Authorization URL</span>
+              <input
+                type="text"
+                value={request.auth.oauth2?.authUrl || ''}
+                onChange={e =>
+                  updateAuth({
+                    oauth2: { ...defaultOAuth2Config(), ...request.auth.oauth2, authUrl: e.target.value },
+                  })
+                }
+                className="bg-dark-700 border border-dark-600 rounded-lg px-3 py-2 text-sm text-dark-100 font-mono"
+                placeholder="https://provider.com/oauth/authorize"
+              />
+            </label>
+          )}
+
+          {/* Token URL */}
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-dark-300 font-medium">Token URL</span>
+            <input
+              type="text"
+              value={request.auth.oauth2?.tokenUrl || ''}
+              onChange={e =>
+                updateAuth({
+                  oauth2: { ...defaultOAuth2Config(), ...request.auth.oauth2, tokenUrl: e.target.value },
+                })
+              }
+              className="bg-dark-700 border border-dark-600 rounded-lg px-3 py-2 text-sm text-dark-100 font-mono"
+              placeholder="https://provider.com/oauth/token"
+            />
+          </label>
+
+          {/* Client ID */}
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-dark-300 font-medium">Client ID</span>
+            <input
+              type="text"
+              value={request.auth.oauth2?.clientId || ''}
+              onChange={e =>
+                updateAuth({
+                  oauth2: { ...defaultOAuth2Config(), ...request.auth.oauth2, clientId: e.target.value },
+                })
+              }
+              className="bg-dark-700 border border-dark-600 rounded-lg px-3 py-2 text-sm text-dark-100 font-mono"
+              placeholder="your-client-id"
+            />
+          </label>
+
+          {/* Client Secret */}
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-dark-300 font-medium">Client Secret</span>
+            <input
+              type="password"
+              value={request.auth.oauth2?.clientSecret || ''}
+              onChange={e =>
+                updateAuth({
+                  oauth2: { ...defaultOAuth2Config(), ...request.auth.oauth2, clientSecret: e.target.value },
+                })
+              }
+              className="bg-dark-700 border border-dark-600 rounded-lg px-3 py-2 text-sm text-dark-100 font-mono"
+              placeholder="your-client-secret"
+            />
+          </label>
+
+          {/* Scope */}
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-dark-300 font-medium">Scope</span>
+            <input
+              type="text"
+              value={request.auth.oauth2?.scope || ''}
+              onChange={e =>
+                updateAuth({
+                  oauth2: { ...defaultOAuth2Config(), ...request.auth.oauth2, scope: e.target.value },
+                })
+              }
+              className="bg-dark-700 border border-dark-600 rounded-lg px-3 py-2 text-sm text-dark-100 font-mono"
+              placeholder="read write (space-separated)"
+            />
+          </label>
+
+          {/* Callback URL (only for auth code flow) */}
+          {request.auth.oauth2?.grantType === 'authorization_code' && (
+            <>
+              <label className="flex flex-col gap-1">
+                <span className="text-xs text-dark-300 font-medium">Callback URL</span>
+                <input
+                  type="text"
+                  value={request.auth.oauth2?.callbackUrl || ''}
+                  onChange={e =>
+                    updateAuth({
+                      oauth2: { ...defaultOAuth2Config(), ...request.auth.oauth2, callbackUrl: e.target.value },
+                    })
+                  }
+                  className="bg-dark-700 border border-dark-600 rounded-lg px-3 py-2 text-sm text-dark-100 font-mono"
+                  placeholder="https://localhost/callback"
+                />
+              </label>
+
+              {/* Get Authorization Code button */}
+              <button
+                onClick={() => {
+                  const cfg = { ...defaultOAuth2Config(), ...request.auth.oauth2 };
+                  const url = buildAuthorizationUrl(cfg);
+                  window.open(url, '_blank', 'width=600,height=700');
+                }}
+                disabled={!request.auth.oauth2?.authUrl || !request.auth.oauth2?.clientId}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-dark-600 text-dark-200 hover:bg-dark-500 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors"
+              >
+                Get Authorization Code
+              </button>
+
+              {/* Authorization code input */}
+              <label className="flex flex-col gap-1">
+                <span className="text-xs text-dark-300 font-medium">Authorization Code</span>
+                <input
+                  type="text"
+                  value={authCode}
+                  onChange={e => setAuthCode(e.target.value)}
+                  className="bg-dark-700 border border-dark-600 rounded-lg px-3 py-2 text-sm text-dark-100 font-mono"
+                  placeholder="Paste the authorization code here"
+                />
+              </label>
+            </>
+          )}
+
+          {/* Token status */}
+          {request.auth.oauth2?.token?.accessToken && (
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-dark-700 border border-dark-600">
+              <div
+                className={`w-2 h-2 rounded-full ${
+                  request.auth.oauth2.token && isTokenExpired(request.auth.oauth2.token)
+                    ? 'bg-accent-red'
+                    : 'bg-accent-green'
+                }`}
+              />
+              <span className="text-xs text-dark-300">
+                {request.auth.oauth2.token && isTokenExpired(request.auth.oauth2.token)
+                  ? 'Token expired'
+                  : 'Token active'}
+              </span>
+              <span className="text-xs text-dark-400 font-mono ml-auto truncate max-w-[200px]">
+                {request.auth.oauth2.token.accessToken.substring(0, 20)}...
+              </span>
+            </div>
+          )}
+
+          {/* Error display */}
+          {tokenError && (
+            <div className="px-3 py-2 rounded-lg bg-accent-red/10 border border-accent-red/30 text-accent-red text-xs">
+              {tokenError}
+            </div>
+          )}
+
+          {/* Get Token / Refresh Token button */}
+          <div className="flex gap-2">
+            <button
+              onClick={async () => {
+                setTokenError(null);
+                setTokenLoading(true);
+                try {
+                  const cfg = { ...defaultOAuth2Config(), ...request.auth.oauth2 };
+                  const token = await fetchOAuth2Token(
+                    cfg,
+                    cfg.grantType === 'authorization_code' ? authCode : undefined,
+                  );
+                  updateAuth({ oauth2: { ...cfg, token } });
+                  setAuthCode('');
+                } catch (err) {
+                  setTokenError(err instanceof Error ? err.message : 'Failed to fetch token');
+                } finally {
+                  setTokenLoading(false);
+                }
+              }}
+              disabled={
+                tokenLoading ||
+                !request.auth.oauth2?.tokenUrl ||
+                !request.auth.oauth2?.clientId ||
+                (request.auth.oauth2?.grantType === 'authorization_code' && !authCode)
+              }
+              className="flex-1 px-4 py-2 text-sm font-medium rounded-lg bg-accent-blue text-white hover:bg-accent-blue/80 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors"
+            >
+              {tokenLoading
+                ? 'Requesting...'
+                : request.auth.oauth2?.token?.accessToken
+                  ? 'Refresh Token'
+                  : 'Get Token'}
+            </button>
+            {request.auth.oauth2?.token?.accessToken && (
+              <button
+                onClick={() =>
+                  updateAuth({
+                    oauth2: { ...defaultOAuth2Config(), ...request.auth.oauth2, token: undefined },
+                  })
+                }
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-dark-600 text-dark-200 hover:bg-dark-500 cursor-pointer transition-colors"
+              >
+                Clear Token
+              </button>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
+}
+
+function defaultOAuth2Config(): import('../types').OAuth2Config {
+  return {
+    grantType: 'client_credentials',
+    authUrl: '',
+    tokenUrl: '',
+    clientId: '',
+    clientSecret: '',
+    scope: '',
+    callbackUrl: '',
+  };
 }

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -12,6 +12,7 @@ import { FormDataEditor } from './FormDataEditor';
 import { BinaryBodyEditor } from './BinaryBodyEditor';
 import { GraphQLEditor } from './GraphQLEditor';
 import { fetchOAuth2Token, buildAuthorizationUrl, isTokenExpired } from '../utils/oauth';
+import { resolveVariables } from '../utils/http';
 
 type RequestTabType = 'params' | 'headers' | 'body' | 'auth';
 
@@ -210,6 +211,7 @@ function BodyEditor({ request }: { request: RequestConfig }) {
 
 function AuthEditor({ request }: { request: RequestConfig }) {
   const updateRequest = useAppStore(s => s.updateRequest);
+  const getActiveVariables = useAppStore(s => s.getActiveVariables);
 
   const [tokenLoading, setTokenLoading] = useState(false);
   const [tokenError, setTokenError] = useState<string | null>(null);
@@ -487,7 +489,10 @@ function AuthEditor({ request }: { request: RequestConfig }) {
               {/* Get Authorization Code button */}
               <button
                 onClick={() => {
-                  const cfg = { ...defaultOAuth2Config(), ...request.auth.oauth2 };
+                  const cfg = resolveOAuth2Config(
+                    { ...defaultOAuth2Config(), ...request.auth.oauth2 },
+                    getActiveVariables(),
+                  );
                   const url = buildAuthorizationUrl(cfg);
                   window.open(url, '_blank', 'width=600,height=700');
                 }}
@@ -546,12 +551,13 @@ function AuthEditor({ request }: { request: RequestConfig }) {
                 setTokenError(null);
                 setTokenLoading(true);
                 try {
-                  const cfg = { ...defaultOAuth2Config(), ...request.auth.oauth2 };
+                  const raw = { ...defaultOAuth2Config(), ...request.auth.oauth2 };
+                  const cfg = resolveOAuth2Config(raw, getActiveVariables());
                   const token = await fetchOAuth2Token(
                     cfg,
                     cfg.grantType === 'authorization_code' ? authCode : undefined,
                   );
-                  updateAuth({ oauth2: { ...cfg, token } });
+                  updateAuth({ oauth2: { ...raw, token } });
                   setAuthCode('');
                 } catch (err) {
                   setTokenError(err instanceof Error ? err.message : 'Failed to fetch token');
@@ -601,5 +607,20 @@ function defaultOAuth2Config(): import('../types').OAuth2Config {
     clientSecret: '',
     scope: '',
     callbackUrl: '',
+  };
+}
+
+function resolveOAuth2Config(
+  cfg: import('../types').OAuth2Config,
+  vars: Record<string, string>,
+): import('../types').OAuth2Config {
+  return {
+    ...cfg,
+    authUrl: resolveVariables(cfg.authUrl, vars),
+    tokenUrl: resolveVariables(cfg.tokenUrl, vars),
+    clientId: resolveVariables(cfg.clientId, vars),
+    clientSecret: resolveVariables(cfg.clientSecret, vars),
+    scope: resolveVariables(cfg.scope, vars),
+    callbackUrl: resolveVariables(cfg.callbackUrl, vars),
   };
 }

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -12,7 +12,7 @@ import { FormDataEditor } from './FormDataEditor';
 import { BinaryBodyEditor } from './BinaryBodyEditor';
 import { GraphQLEditor } from './GraphQLEditor';
 import { fetchOAuth2Token, buildAuthorizationUrl, isTokenExpired } from '../utils/oauth';
-import { resolveVariables } from '../utils/http';
+import { resolveOAuth2Variables } from '../utils/http';
 
 type RequestTabType = 'params' | 'headers' | 'body' | 'auth';
 
@@ -226,6 +226,10 @@ function AuthEditor({ request }: { request: RequestConfig }) {
   ];
 
   const updateAuth = (updates: Partial<RequestConfig['auth']>) => {
+    if (updates.type && updates.type !== request.auth.type) {
+      setTokenError(null);
+      setAuthCode('');
+    }
     updateRequest(request.id, {
       auth: { ...request.auth, ...updates },
     });
@@ -489,7 +493,7 @@ function AuthEditor({ request }: { request: RequestConfig }) {
               {/* Get Authorization Code button */}
               <button
                 onClick={() => {
-                  const cfg = resolveOAuth2Config(
+                  const cfg = resolveOAuth2Variables(
                     { ...defaultOAuth2Config(), ...request.auth.oauth2 },
                     getActiveVariables(),
                   );
@@ -554,7 +558,7 @@ function AuthEditor({ request }: { request: RequestConfig }) {
                 setTokenLoading(true);
                 try {
                   const raw = { ...defaultOAuth2Config(), ...request.auth.oauth2 };
-                  const cfg = resolveOAuth2Config(raw, getActiveVariables());
+                  const cfg = resolveOAuth2Variables(raw, getActiveVariables());
                   const token = await fetchOAuth2Token(
                     cfg,
                     cfg.grantType === 'authorization_code' ? authCode : undefined,
@@ -612,17 +616,3 @@ function defaultOAuth2Config(): import('../types').OAuth2Config {
   };
 }
 
-function resolveOAuth2Config(
-  cfg: import('../types').OAuth2Config,
-  vars: Record<string, string>,
-): import('../types').OAuth2Config {
-  return {
-    ...cfg,
-    authUrl: resolveVariables(cfg.authUrl, vars),
-    tokenUrl: resolveVariables(cfg.tokenUrl, vars),
-    clientId: resolveVariables(cfg.clientId, vars),
-    clientSecret: resolveVariables(cfg.clientSecret, vars),
-    scope: resolveVariables(cfg.scope, vars),
-    callbackUrl: resolveVariables(cfg.callbackUrl, vars),
-  };
-}

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -505,7 +505,7 @@ function AuthEditor({ request }: { request: RequestConfig }) {
                     getActiveVariables(),
                   );
                   const url = buildAuthorizationUrl(cfg);
-                  window.open(url, '_blank', 'width=600,height=700');
+                  window.open(url, '_blank', 'width=600,height=700,noopener,noreferrer');
                 }}
                 disabled={!request.auth.oauth2?.authUrl || !request.auth.oauth2?.clientId}
                 className="px-4 py-2 text-sm font-medium rounded-lg bg-dark-600 text-dark-200 hover:bg-dark-500 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors"

--- a/src/components/UrlBar.tsx
+++ b/src/components/UrlBar.tsx
@@ -1,4 +1,4 @@
-import { Send, Loader2 } from 'lucide-react';
+import { Send, Loader2, ShieldCheck, ShieldOff } from 'lucide-react';
 import type { HttpMethod, RequestConfig } from '../types';
 import { useAppStore } from '../store';
 import { sendRequest, resolveRequestVariables } from '../utils/http';
@@ -79,6 +79,19 @@ export function UrlBar({ request }: Props) {
         placeholder="Enter URL or paste cURL command..."
         className="flex-1 bg-dark-700 border border-dark-500 rounded-lg px-4 py-2.5 text-sm text-dark-100 placeholder:text-dark-400 font-mono"
       />
+
+      {/* SSL Verification Toggle */}
+      <button
+        onClick={() => updateRequest(request.id, { sslVerification: request.sslVerification === false ? true : false })}
+        title={request.sslVerification === false ? 'SSL verification disabled — click to enable' : 'SSL verification enabled — click to disable'}
+        className={`p-2.5 rounded-lg border transition-colors cursor-pointer ${
+          request.sslVerification === false
+            ? 'bg-yellow-900/30 border-yellow-600/50 text-yellow-400 hover:bg-yellow-900/50'
+            : 'bg-dark-700 border-dark-500 text-dark-400 hover:text-dark-200'
+        }`}
+      >
+        {request.sslVerification === false ? <ShieldOff size={16} /> : <ShieldCheck size={16} />}
+      </button>
 
       {/* Send Button */}
       <button

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,6 +75,7 @@ export interface RequestConfig {
     };
   };
   auth: AuthConfig;
+  sslVerification?: boolean;
 }
 
 export interface ResponseData {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,8 @@ export interface OAuth2Token {
   obtainedAt?: number;
 }
 
+export type OAuth2ClientAuth = 'post' | 'basic';
+
 export interface OAuth2Config {
   grantType: OAuth2GrantType;
   authUrl: string;
@@ -38,6 +40,7 @@ export interface OAuth2Config {
   clientSecret: string;
   scope: string;
   callbackUrl: string;
+  clientAuthMethod?: OAuth2ClientAuth;
   state?: string;
   token?: OAuth2Token;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,13 +17,37 @@ export interface FormDataEntry extends KeyValuePair {
 
 export type BodyType = 'none' | 'json' | 'text' | 'xml' | 'form-data' | 'x-www-form-urlencoded' | 'binary' | 'graphql';
 
-export type AuthType = 'none' | 'basic' | 'bearer' | 'api-key';
+export type AuthType = 'none' | 'basic' | 'bearer' | 'api-key' | 'oauth2';
+
+export type OAuth2GrantType = 'authorization_code' | 'client_credentials';
+
+export interface OAuth2Token {
+  accessToken: string;
+  tokenType?: string;
+  expiresIn?: number;
+  refreshToken?: string;
+  scope?: string;
+  obtainedAt?: number;
+}
+
+export interface OAuth2Config {
+  grantType: OAuth2GrantType;
+  authUrl: string;
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+  scope: string;
+  callbackUrl: string;
+  state?: string;
+  token?: OAuth2Token;
+}
 
 export interface AuthConfig {
   type: AuthType;
   basic?: { username: string; password: string };
   bearer?: { token: string };
   apiKey?: { key: string; value: string; addTo: 'header' | 'query' };
+  oauth2?: OAuth2Config;
 }
 
 export interface RequestConfig {

--- a/src/utils/__tests__/http.test.ts
+++ b/src/utils/__tests__/http.test.ts
@@ -97,6 +97,59 @@ describe('buildHeaders', () => {
     const result = buildHeaders([], auth);
     expect(result).toEqual({});
   });
+
+  it('adds OAuth 2.0 Bearer header from stored token', () => {
+    const auth: AuthConfig = {
+      type: 'oauth2',
+      oauth2: {
+        grantType: 'client_credentials',
+        authUrl: '',
+        tokenUrl: 'https://auth.example.com/token',
+        clientId: 'id',
+        clientSecret: 'secret',
+        scope: '',
+        callbackUrl: '',
+        token: { accessToken: 'oauth-tok-123', tokenType: 'Bearer', obtainedAt: Date.now() },
+      },
+    };
+    const result = buildHeaders([], auth);
+    expect(result['Authorization']).toBe('Bearer oauth-tok-123');
+  });
+
+  it('capitalizes token type for OAuth 2.0 header', () => {
+    const auth: AuthConfig = {
+      type: 'oauth2',
+      oauth2: {
+        grantType: 'client_credentials',
+        authUrl: '',
+        tokenUrl: '',
+        clientId: '',
+        clientSecret: '',
+        scope: '',
+        callbackUrl: '',
+        token: { accessToken: 'tok', tokenType: 'mac' },
+      },
+    };
+    const result = buildHeaders([], auth);
+    expect(result['Authorization']).toBe('Mac tok');
+  });
+
+  it('does not add Authorization when oauth2 has no token', () => {
+    const auth: AuthConfig = {
+      type: 'oauth2',
+      oauth2: {
+        grantType: 'client_credentials',
+        authUrl: '',
+        tokenUrl: 'https://auth.example.com/token',
+        clientId: 'id',
+        clientSecret: 'secret',
+        scope: '',
+        callbackUrl: '',
+      },
+    };
+    const result = buildHeaders([], auth);
+    expect(result).toEqual({});
+  });
 });
 
 // ─── buildBody ───────────────────────────────────────────────────────────────
@@ -434,6 +487,37 @@ describe('resolveRequestVariables', () => {
     const original = req.url;
     resolveRequestVariables(req, vars);
     expect(req.url).toBe(original);
+  });
+
+  it('resolves variables in OAuth 2.0 config', () => {
+    const req = createDefaultRequest({
+      url: 'https://api.example.com',
+      auth: {
+        type: 'oauth2',
+        oauth2: {
+          grantType: 'client_credentials',
+          authUrl: '{{host}}/authorize',
+          tokenUrl: '{{host}}/token',
+          clientId: '{{clientId}}',
+          clientSecret: '{{secret}}',
+          scope: '{{scope}}',
+          callbackUrl: '{{callback}}',
+        },
+      },
+    });
+    const resolved = resolveRequestVariables(req, {
+      ...vars,
+      clientId: 'my-id',
+      secret: 'my-secret',
+      scope: 'read',
+      callback: 'https://localhost/cb',
+    });
+    expect(resolved.auth.oauth2?.tokenUrl).toBe('api.test/token');
+    expect(resolved.auth.oauth2?.authUrl).toBe('api.test/authorize');
+    expect(resolved.auth.oauth2?.clientId).toBe('my-id');
+    expect(resolved.auth.oauth2?.clientSecret).toBe('my-secret');
+    expect(resolved.auth.oauth2?.scope).toBe('read');
+    expect(resolved.auth.oauth2?.callbackUrl).toBe('https://localhost/cb');
   });
 });
 

--- a/src/utils/__tests__/http.test.ts
+++ b/src/utils/__tests__/http.test.ts
@@ -116,8 +116,8 @@ describe('buildHeaders', () => {
     expect(result['Authorization']).toBe('Bearer oauth-tok-123');
   });
 
-  it('capitalizes token type for OAuth 2.0 header', () => {
-    const auth: AuthConfig = {
+  it('normalizes "bearer" casing but preserves other token types', () => {
+    const makeAuth = (tokenType: string): AuthConfig => ({
       type: 'oauth2',
       oauth2: {
         grantType: 'client_credentials',
@@ -127,11 +127,15 @@ describe('buildHeaders', () => {
         clientSecret: '',
         scope: '',
         callbackUrl: '',
-        token: { accessToken: 'tok', tokenType: 'mac' },
+        token: { accessToken: 'tok', tokenType },
       },
-    };
-    const result = buildHeaders([], auth);
-    expect(result['Authorization']).toBe('Mac tok');
+    });
+    // "bearer" variants all normalize to "Bearer"
+    expect(buildHeaders([], makeAuth('bearer'))['Authorization']).toBe('Bearer tok');
+    expect(buildHeaders([], makeAuth('BEARER'))['Authorization']).toBe('Bearer tok');
+    // Non-bearer types are preserved as-is
+    expect(buildHeaders([], makeAuth('MAC'))['Authorization']).toBe('MAC tok');
+    expect(buildHeaders([], makeAuth('DPoP'))['Authorization']).toBe('DPoP tok');
   });
 
   it('does not add Authorization when oauth2 has no token', () => {

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildAuthorizationUrl, isTokenExpired, fetchOAuth2Token } from '../oauth';
+import type { OAuth2Config, OAuth2Token } from '../../types';
+
+function makeConfig(overrides?: Partial<OAuth2Config>): OAuth2Config {
+  return {
+    grantType: 'client_credentials',
+    authUrl: 'https://auth.example.com/authorize',
+    tokenUrl: 'https://auth.example.com/token',
+    clientId: 'my-client',
+    clientSecret: 'my-secret',
+    scope: 'read write',
+    callbackUrl: 'https://localhost/callback',
+    ...overrides,
+  };
+}
+
+// ─── buildAuthorizationUrl ──────────────────────────────────────────────────
+
+describe('buildAuthorizationUrl', () => {
+  it('builds a URL with required parameters', () => {
+    const config = makeConfig({ grantType: 'authorization_code' });
+    const url = buildAuthorizationUrl(config);
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe('https://auth.example.com/authorize');
+    expect(parsed.searchParams.get('response_type')).toBe('code');
+    expect(parsed.searchParams.get('client_id')).toBe('my-client');
+    expect(parsed.searchParams.get('redirect_uri')).toBe('https://localhost/callback');
+    expect(parsed.searchParams.get('scope')).toBe('read write');
+  });
+
+  it('includes state when provided', () => {
+    const config = makeConfig({ state: 'xyz123' });
+    const url = buildAuthorizationUrl(config);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('state')).toBe('xyz123');
+  });
+
+  it('omits scope when empty', () => {
+    const config = makeConfig({ scope: '' });
+    const url = buildAuthorizationUrl(config);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has('scope')).toBe(false);
+  });
+
+  it('appends with & when authUrl already has query params', () => {
+    const config = makeConfig({ authUrl: 'https://auth.example.com/authorize?existing=1' });
+    const url = buildAuthorizationUrl(config);
+    expect(url).toContain('?existing=1&');
+    expect(url).toContain('response_type=code');
+  });
+});
+
+// ─── isTokenExpired ─────────────────────────────────────────────────────────
+
+describe('isTokenExpired', () => {
+  it('returns false when expiresIn is not set', () => {
+    const token: OAuth2Token = { accessToken: 'abc' };
+    expect(isTokenExpired(token)).toBe(false);
+  });
+
+  it('returns false when obtainedAt is not set', () => {
+    const token: OAuth2Token = { accessToken: 'abc', expiresIn: 3600 };
+    expect(isTokenExpired(token)).toBe(false);
+  });
+
+  it('returns false for a fresh token', () => {
+    const token: OAuth2Token = {
+      accessToken: 'abc',
+      expiresIn: 3600,
+      obtainedAt: Date.now(),
+    };
+    expect(isTokenExpired(token)).toBe(false);
+  });
+
+  it('returns true for an expired token', () => {
+    const token: OAuth2Token = {
+      accessToken: 'abc',
+      expiresIn: 3600,
+      obtainedAt: Date.now() - 4000 * 1000,
+    };
+    expect(isTokenExpired(token)).toBe(true);
+  });
+
+  it('returns true within the 30-second buffer before expiry', () => {
+    const token: OAuth2Token = {
+      accessToken: 'abc',
+      expiresIn: 60,
+      obtainedAt: Date.now() - 40 * 1000,
+    };
+    // 60s - 40s = 20s remaining, which is within the 30s buffer
+    expect(isTokenExpired(token)).toBe(true);
+  });
+});
+
+// ─── fetchOAuth2Token ───────────────────────────────────────────────────────
+
+describe('fetchOAuth2Token', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends client_credentials request and parses token', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          access_token: 'tok_123',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'read',
+        }),
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    const config = makeConfig();
+    const token = await fetchOAuth2Token(config);
+
+    expect(token.accessToken).toBe('tok_123');
+    expect(token.tokenType).toBe('Bearer');
+    expect(token.expiresIn).toBe(3600);
+    expect(token.obtainedAt).toBeDefined();
+
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(call[0]).toBe('/api/oauth/token');
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    expect(body.grantType).toBe('client_credentials');
+    expect(body.clientId).toBe('my-client');
+  });
+
+  it('sends authorization_code request with auth code', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          access_token: 'tok_456',
+          token_type: 'bearer',
+          refresh_token: 'ref_789',
+        }),
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    const config = makeConfig({ grantType: 'authorization_code' });
+    const token = await fetchOAuth2Token(config, 'code_abc');
+
+    expect(token.accessToken).toBe('tok_456');
+    expect(token.refreshToken).toBe('ref_789');
+
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+    expect(body.grantType).toBe('authorization_code');
+    expect(body.code).toBe('code_abc');
+  });
+
+  it('throws on error response', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          error: 'invalid_grant',
+          error_description: 'The code has expired',
+        }),
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    const config = makeConfig();
+    await expect(fetchOAuth2Token(config)).rejects.toThrow('OAuth error: The code has expired');
+  });
+
+  it('defaults tokenType to Bearer when not provided', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ access_token: 'tok' }),
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    const token = await fetchOAuth2Token(makeConfig());
+    expect(token.tokenType).toBe('Bearer');
+  });
+});

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -43,6 +43,13 @@ describe('buildAuthorizationUrl', () => {
     expect(parsed.searchParams.has('scope')).toBe(false);
   });
 
+  it('omits redirect_uri when callbackUrl is empty', () => {
+    const config = makeConfig({ callbackUrl: '' });
+    const url = buildAuthorizationUrl(config);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has('redirect_uri')).toBe(false);
+  });
+
   it('appends with & when authUrl already has query params', () => {
     const config = makeConfig({ authUrl: 'https://auth.example.com/authorize?existing=1' });
     const url = buildAuthorizationUrl(config);

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -176,6 +176,38 @@ describe('fetchOAuth2Token', () => {
     await expect(fetchOAuth2Token(config)).rejects.toThrow('OAuth error: The code has expired');
   });
 
+  it('throws when response is missing access_token', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ token_type: 'Bearer', expires_in: 3600 }),
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    await expect(fetchOAuth2Token(makeConfig())).rejects.toThrow('OAuth error: response missing access_token');
+  });
+
+  it('only sends code and redirectUri for authorization_code grant', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ access_token: 'tok' }),
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    // client_credentials should NOT include code or redirectUri
+    await fetchOAuth2Token(makeConfig({ grantType: 'client_credentials' }));
+    const ccBody = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+    expect(ccBody.code).toBeUndefined();
+    expect(ccBody.redirectUri).toBeUndefined();
+
+    // authorization_code should include them
+    await fetchOAuth2Token(makeConfig({ grantType: 'authorization_code' }), 'my-code');
+    const acBody = JSON.parse((vi.mocked(fetch).mock.calls[1][1] as RequestInit).body as string);
+    expect(acBody.code).toBe('my-code');
+    expect(acBody.redirectUri).toBe('https://localhost/callback');
+  });
+
   it('defaults tokenType to Bearer when not provided', async () => {
     const mockResponse = {
       ok: true,

--- a/src/utils/__tests__/openapi.test.ts
+++ b/src/utils/__tests__/openapi.test.ts
@@ -1237,6 +1237,62 @@ describe('parseOpenApiSpec - authentication', () => {
     expect(result.requests[0].auth.oauth2?.scope).toBe('read');
   });
 
+  it('uses operation-required scopes instead of all flow scopes for OAuth2', () => {
+    const result = parseOpenApiSpec({
+      openapi: '3.0.0',
+      info: { title: 'API', version: '1.0' },
+      paths: {
+        '/narrow': {
+          get: { security: [{ OAuth: ['read'] }] },
+        },
+      },
+      components: {
+        securitySchemes: {
+          OAuth: {
+            type: 'oauth2',
+            flows: {
+              authorizationCode: {
+                authorizationUrl: 'https://auth.example.com/authorize',
+                tokenUrl: 'https://auth.example.com/token',
+                scopes: { read: 'Read', write: 'Write', admin: 'Admin' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Operation only requires "read", not all three flow scopes
+    expect(result.requests[0].auth.oauth2?.scope).toBe('read');
+  });
+
+  it('falls back to all flow scopes when operation specifies empty scope list', () => {
+    const result = parseOpenApiSpec({
+      openapi: '3.0.0',
+      info: { title: 'API', version: '1.0' },
+      paths: {
+        '/all': {
+          get: { security: [{ OAuth: [] }] },
+        },
+      },
+      components: {
+        securitySchemes: {
+          OAuth: {
+            type: 'oauth2',
+            flows: {
+              clientCredentials: {
+                tokenUrl: 'https://auth.example.com/token',
+                scopes: { read: 'Read', write: 'Write' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.requests[0].auth.oauth2?.scope).toBe('read write');
+  });
+
   it('operation-level security overrides global', () => {
     const result = parseOpenApiSpec({
       openapi: '3.0.0',

--- a/src/utils/__tests__/openapi.test.ts
+++ b/src/utils/__tests__/openapi.test.ts
@@ -1344,6 +1344,52 @@ describe('parseOpenApiSpec - authentication', () => {
     expect(result.requests[0].auth.type).toBe('basic');
   });
 
+  it('maps Swagger 2.0 OAuth2 accessCode flow to authorization_code', () => {
+    const result = parseOpenApiSpec({
+      swagger: '2.0',
+      info: { title: 'API', version: '1.0' },
+      paths: { '/secure': { get: {} } },
+      securityDefinitions: {
+        OAuth: {
+          type: 'oauth2',
+          flow: 'accessCode',
+          authorizationUrl: 'https://auth.example.com/authorize',
+          tokenUrl: 'https://auth.example.com/token',
+          scopes: { read: 'Read', write: 'Write' },
+        },
+      },
+      security: [{ OAuth: ['read'] }],
+    } as any);
+
+    expect(result.requests[0].auth.type).toBe('oauth2');
+    expect(result.requests[0].auth.oauth2?.grantType).toBe('authorization_code');
+    expect(result.requests[0].auth.oauth2?.authUrl).toBe('https://auth.example.com/authorize');
+    expect(result.requests[0].auth.oauth2?.tokenUrl).toBe('https://auth.example.com/token');
+    expect(result.requests[0].auth.oauth2?.scope).toBe('read');
+  });
+
+  it('maps Swagger 2.0 OAuth2 application flow to client_credentials', () => {
+    const result = parseOpenApiSpec({
+      swagger: '2.0',
+      info: { title: 'API', version: '1.0' },
+      paths: { '/secure': { get: {} } },
+      securityDefinitions: {
+        OAuth: {
+          type: 'oauth2',
+          flow: 'application',
+          tokenUrl: 'https://auth.example.com/token',
+          scopes: { api: 'API access' },
+        },
+      },
+      security: [{ OAuth: [] }],
+    } as any);
+
+    expect(result.requests[0].auth.type).toBe('oauth2');
+    expect(result.requests[0].auth.oauth2?.grantType).toBe('client_credentials');
+    expect(result.requests[0].auth.oauth2?.tokenUrl).toBe('https://auth.example.com/token');
+    expect(result.requests[0].auth.oauth2?.scope).toBe('');
+  });
+
   it('resolves $ref in security schemes', () => {
     const result = parseOpenApiSpec({
       openapi: '3.0.0',

--- a/src/utils/__tests__/openapi.test.ts
+++ b/src/utils/__tests__/openapi.test.ts
@@ -1230,7 +1230,11 @@ describe('parseOpenApiSpec - authentication', () => {
       security: [{ OAuth: ['read'] }],
     });
 
-    expect(result.requests[0].auth.type).toBe('bearer');
+    expect(result.requests[0].auth.type).toBe('oauth2');
+    expect(result.requests[0].auth.oauth2?.grantType).toBe('authorization_code');
+    expect(result.requests[0].auth.oauth2?.authUrl).toBe('https://auth.example.com/authorize');
+    expect(result.requests[0].auth.oauth2?.tokenUrl).toBe('https://auth.example.com/token');
+    expect(result.requests[0].auth.oauth2?.scope).toBe('read');
   });
 
   it('operation-level security overrides global', () => {

--- a/src/utils/__tests__/openapi.test.ts
+++ b/src/utils/__tests__/openapi.test.ts
@@ -1266,7 +1266,7 @@ describe('parseOpenApiSpec - authentication', () => {
     expect(result.requests[0].auth.oauth2?.scope).toBe('read');
   });
 
-  it('falls back to all flow scopes when operation specifies empty scope list', () => {
+  it('preserves empty scope when operation explicitly requires none', () => {
     const result = parseOpenApiSpec({
       openapi: '3.0.0',
       info: { title: 'API', version: '1.0' },
@@ -1290,7 +1290,8 @@ describe('parseOpenApiSpec - authentication', () => {
       },
     });
 
-    expect(result.requests[0].auth.oauth2?.scope).toBe('read write');
+    // Empty array = no scopes required, not "all scopes"
+    expect(result.requests[0].auth.oauth2?.scope).toBe('');
   });
 
   it('operation-level security overrides global', () => {

--- a/src/utils/__tests__/postman.test.ts
+++ b/src/utils/__tests__/postman.test.ts
@@ -420,7 +420,7 @@ describe('parsePostmanCollection: auth', () => {
     expect(requests[0].auth.type).toBe('none');
   });
 
-  it('returns no auth for unsupported auth types', () => {
+  it('maps oauth2 auth type from Postman', () => {
     const col = postmanCollection({
       item: [{
         name: 'Test',
@@ -428,6 +428,22 @@ describe('parsePostmanCollection: auth', () => {
           method: 'GET',
           url: 'https://example.com',
           auth: { type: 'oauth2', oauth2: [] },
+        },
+      }],
+    });
+    const { requests } = parsePostmanCollection(col as any);
+    expect(requests[0].auth.type).toBe('oauth2');
+    expect(requests[0].auth.oauth2?.grantType).toBe('client_credentials');
+  });
+
+  it('returns no auth for unsupported auth types', () => {
+    const col = postmanCollection({
+      item: [{
+        name: 'Test',
+        request: {
+          method: 'GET',
+          url: 'https://example.com',
+          auth: { type: 'digest', digest: [] },
         },
       }],
     });

--- a/src/utils/__tests__/postman.test.ts
+++ b/src/utils/__tests__/postman.test.ts
@@ -420,20 +420,47 @@ describe('parsePostmanCollection: auth', () => {
     expect(requests[0].auth.type).toBe('none');
   });
 
-  it('maps oauth2 auth type from Postman', () => {
+  it('maps oauth2 client_credentials auth type from Postman', () => {
     const col = postmanCollection({
       item: [{
         name: 'Test',
         request: {
           method: 'GET',
           url: 'https://example.com',
-          auth: { type: 'oauth2', oauth2: [] },
+          auth: {
+            type: 'oauth2',
+            oauth2: [
+              { key: 'grant_type', value: 'client_credentials' },
+              { key: 'accessTokenUrl', value: 'https://auth.example.com/token' },
+              { key: 'clientId', value: 'my-id' },
+            ],
+          },
         },
       }],
     });
     const { requests } = parsePostmanCollection(col as any);
     expect(requests[0].auth.type).toBe('oauth2');
     expect(requests[0].auth.oauth2?.grantType).toBe('client_credentials');
+    expect(requests[0].auth.oauth2?.tokenUrl).toBe('https://auth.example.com/token');
+    expect(requests[0].auth.oauth2?.clientId).toBe('my-id');
+  });
+
+  it('falls back to no auth for unsupported oauth2 grant types', () => {
+    const col = postmanCollection({
+      item: [{
+        name: 'Test',
+        request: {
+          method: 'GET',
+          url: 'https://example.com',
+          auth: {
+            type: 'oauth2',
+            oauth2: [{ key: 'grant_type', value: 'implicit' }],
+          },
+        },
+      }],
+    });
+    const { requests } = parsePostmanCollection(col as any);
+    expect(requests[0].auth.type).toBe('none');
   });
 
   it('returns no auth for unsupported auth types', () => {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -263,6 +263,7 @@ export async function sendRequest(request: RequestConfig): Promise<ResponseData>
       headers,
       bodyType: 'form-data',
       formDataEntries,
+      sslVerification: request.sslVerification !== false,
     });
   } else if (request.body.type === 'binary') {
     const file = getFile(request.id, BINARY_ENTRY_ID);
@@ -280,6 +281,7 @@ export async function sendRequest(request: RequestConfig): Promise<ResponseData>
       headers,
       bodyType: 'binary',
       binary: { base64, fileName: file.name, fileType: file.type || 'application/octet-stream' },
+      sslVerification: request.sslVerification !== false,
     });
   } else {
     proxyBody = JSON.stringify({
@@ -288,6 +290,7 @@ export async function sendRequest(request: RequestConfig): Promise<ResponseData>
       headers,
       body: body instanceof FormData ? Object.fromEntries(body) : body,
       bodyType: request.body.type,
+      sslVerification: request.sslVerification !== false,
     });
   }
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -431,11 +431,20 @@ export function parseCurlCommand(curlStr: string): Partial<RequestConfig> {
     };
   }
 
+  // Detect --insecure / -k flag
+  if (/(?:^|\s)(?:--insecure|-k)(?:\s|$)/.test(cleaned)) {
+    result.sslVerification = false;
+  }
+
   return result;
 }
 
 export function generateCurlCommand(request: RequestConfig): string {
   const parts: string[] = ['curl'];
+
+  if (request.sslVerification === false) {
+    parts.push('--insecure');
+  }
 
   if (request.method !== 'GET') {
     parts.push(`-X ${request.method}`);

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -157,6 +157,22 @@ export function resolveRequestVariables(request: RequestConfig, variables: Recor
   };
 }
 
+export function resolveOAuth2Variables(
+  oauth2: import('../types').OAuth2Config,
+  variables: Record<string, string>,
+): import('../types').OAuth2Config {
+  return {
+    ...oauth2,
+    authUrl: resolveVariables(oauth2.authUrl, variables),
+    tokenUrl: resolveVariables(oauth2.tokenUrl, variables),
+    clientId: resolveVariables(oauth2.clientId, variables),
+    clientSecret: resolveVariables(oauth2.clientSecret, variables),
+    scope: resolveVariables(oauth2.scope, variables),
+    callbackUrl: resolveVariables(oauth2.callbackUrl, variables),
+    state: oauth2.state ? resolveVariables(oauth2.state, variables) : undefined,
+  };
+}
+
 function resolveAuthVariables(auth: AuthConfig, variables: Record<string, string>): AuthConfig {
   const resolved = { ...auth };
   if (resolved.basic) {
@@ -176,16 +192,7 @@ function resolveAuthVariables(auth: AuthConfig, variables: Record<string, string
     };
   }
   if (resolved.oauth2) {
-    resolved.oauth2 = {
-      ...resolved.oauth2,
-      authUrl: resolveVariables(resolved.oauth2.authUrl, variables),
-      tokenUrl: resolveVariables(resolved.oauth2.tokenUrl, variables),
-      clientId: resolveVariables(resolved.oauth2.clientId, variables),
-      clientSecret: resolveVariables(resolved.oauth2.clientSecret, variables),
-      scope: resolveVariables(resolved.oauth2.scope, variables),
-      callbackUrl: resolveVariables(resolved.oauth2.callbackUrl, variables),
-      state: resolved.oauth2.state ? resolveVariables(resolved.oauth2.state, variables) : undefined,
-    };
+    resolved.oauth2 = resolveOAuth2Variables(resolved.oauth2, variables);
   }
   return resolved;
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -36,7 +36,8 @@ export function buildHeaders(headers: KeyValuePair[], auth: AuthConfig): Record<
     case 'oauth2':
       if (auth.oauth2?.token?.accessToken) {
         const tokenType = auth.oauth2.token.tokenType || 'Bearer';
-        const prefix = tokenType.charAt(0).toUpperCase() + tokenType.slice(1).toLowerCase();
+        // Normalize common "bearer" casing; preserve everything else (e.g. "MAC", "DPoP")
+        const prefix = tokenType.toLowerCase() === 'bearer' ? 'Bearer' : tokenType;
         result['Authorization'] = `${prefix} ${auth.oauth2.token.accessToken}`;
       }
       break;
@@ -183,6 +184,7 @@ function resolveAuthVariables(auth: AuthConfig, variables: Record<string, string
       clientSecret: resolveVariables(resolved.oauth2.clientSecret, variables),
       scope: resolveVariables(resolved.oauth2.scope, variables),
       callbackUrl: resolveVariables(resolved.oauth2.callbackUrl, variables),
+      state: resolved.oauth2.state ? resolveVariables(resolved.oauth2.state, variables) : undefined,
     };
   }
   return resolved;

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -33,6 +33,13 @@ export function buildHeaders(headers: KeyValuePair[], auth: AuthConfig): Record<
         result[auth.apiKey.key] = auth.apiKey.value;
       }
       break;
+    case 'oauth2':
+      if (auth.oauth2?.token?.accessToken) {
+        const tokenType = auth.oauth2.token.tokenType || 'Bearer';
+        const prefix = tokenType.charAt(0).toUpperCase() + tokenType.slice(1).toLowerCase();
+        result['Authorization'] = `${prefix} ${auth.oauth2.token.accessToken}`;
+      }
+      break;
   }
 
   return result;
@@ -165,6 +172,17 @@ function resolveAuthVariables(auth: AuthConfig, variables: Record<string, string
       ...resolved.apiKey,
       key: resolveVariables(resolved.apiKey.key, variables),
       value: resolveVariables(resolved.apiKey.value, variables),
+    };
+  }
+  if (resolved.oauth2) {
+    resolved.oauth2 = {
+      ...resolved.oauth2,
+      authUrl: resolveVariables(resolved.oauth2.authUrl, variables),
+      tokenUrl: resolveVariables(resolved.oauth2.tokenUrl, variables),
+      clientId: resolveVariables(resolved.oauth2.clientId, variables),
+      clientSecret: resolveVariables(resolved.oauth2.clientSecret, variables),
+      scope: resolveVariables(resolved.oauth2.scope, variables),
+      callbackUrl: resolveVariables(resolved.oauth2.callbackUrl, variables),
     };
   }
   return resolved;

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -51,8 +51,11 @@ export function buildAuthorizationUrl(config: OAuth2Config): string {
   const params = new URLSearchParams({
     response_type: 'code',
     client_id: config.clientId,
-    redirect_uri: config.callbackUrl,
   });
+
+  if (config.callbackUrl) {
+    params.set('redirect_uri', config.callbackUrl);
+  }
 
   if (config.scope) {
     params.set('scope', config.scope);

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -8,18 +8,25 @@ export async function fetchOAuth2Token(
   config: OAuth2Config,
   authorizationCode?: string,
 ): Promise<OAuth2Token> {
+  const payload: Record<string, string | undefined> = {
+    tokenUrl: config.tokenUrl,
+    grantType: config.grantType,
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    scope: config.scope,
+  };
+
+  if (config.grantType === 'authorization_code') {
+    payload.code = authorizationCode;
+    if (config.callbackUrl) {
+      payload.redirectUri = config.callbackUrl;
+    }
+  }
+
   const response = await fetch('/api/oauth/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      tokenUrl: config.tokenUrl,
-      grantType: config.grantType,
-      clientId: config.clientId,
-      clientSecret: config.clientSecret,
-      code: authorizationCode,
-      redirectUri: config.callbackUrl,
-      scope: config.scope,
-    }),
+    body: JSON.stringify(payload),
   });
 
   const data = await response.json();
@@ -31,6 +38,10 @@ export async function fetchOAuth2Token(
 
   if (!response.ok) {
     throw new Error(`Token request failed with status ${response.status}`);
+  }
+
+  if (!data.access_token) {
+    throw new Error('OAuth error: response missing access_token');
   }
 
   return {

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -1,0 +1,76 @@
+import type { OAuth2Config, OAuth2Token } from '../types';
+
+/**
+ * Exchange an authorization code or client credentials for an access token
+ * via the proxy server (avoids CORS issues with token endpoints).
+ */
+export async function fetchOAuth2Token(
+  config: OAuth2Config,
+  authorizationCode?: string,
+): Promise<OAuth2Token> {
+  const response = await fetch('/api/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      tokenUrl: config.tokenUrl,
+      grantType: config.grantType,
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      code: authorizationCode,
+      redirectUri: config.callbackUrl,
+      scope: config.scope,
+    }),
+  });
+
+  const data = await response.json();
+
+  if (data.error) {
+    const detail = data.error_description || data.error;
+    throw new Error(`OAuth error: ${detail}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Token request failed with status ${response.status}`);
+  }
+
+  return {
+    accessToken: data.access_token,
+    tokenType: data.token_type || 'Bearer',
+    expiresIn: data.expires_in,
+    refreshToken: data.refresh_token,
+    scope: data.scope,
+    obtainedAt: Date.now(),
+  };
+}
+
+/**
+ * Build the authorization URL for the authorization code flow.
+ * The user opens this URL in a browser to grant access.
+ */
+export function buildAuthorizationUrl(config: OAuth2Config): string {
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: config.clientId,
+    redirect_uri: config.callbackUrl,
+  });
+
+  if (config.scope) {
+    params.set('scope', config.scope);
+  }
+
+  if (config.state) {
+    params.set('state', config.state);
+  }
+
+  const separator = config.authUrl.includes('?') ? '&' : '?';
+  return `${config.authUrl}${separator}${params.toString()}`;
+}
+
+/**
+ * Check whether a stored token has expired (with a 30-second buffer).
+ */
+export function isTokenExpired(token: OAuth2Token): boolean {
+  if (!token.expiresIn || !token.obtainedAt) return false;
+  const expiresAt = token.obtainedAt + token.expiresIn * 1000;
+  return Date.now() > expiresAt - 30_000;
+}

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -7,13 +7,16 @@ import type { OAuth2Config, OAuth2Token } from '../types';
 export async function fetchOAuth2Token(
   config: OAuth2Config,
   authorizationCode?: string,
+  sslVerification?: boolean,
 ): Promise<OAuth2Token> {
-  const payload: Record<string, string | undefined> = {
+  const payload: Record<string, string | boolean | undefined> = {
     tokenUrl: config.tokenUrl,
     grantType: config.grantType,
     clientId: config.clientId,
     clientSecret: config.clientSecret,
     scope: config.scope,
+    sslVerification: sslVerification !== false,
+    clientAuthMethod: config.clientAuthMethod || 'post',
   };
 
   if (config.grantType === 'authorization_code') {

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1180,13 +1180,14 @@ function extractAuth(spec: OpenApiSpec, operation: Operation): AuthConfig {
     if (!rawScheme) continue;
 
     const scheme = resolveSecuritySchemeRef(spec, rawScheme as SecuritySchemeOrRef);
-    return convertSecurityScheme(scheme);
+    const requiredScopes = req[schemeName] || [];
+    return convertSecurityScheme(scheme, requiredScopes);
   }
 
   return { type: 'none' };
 }
 
-function convertSecurityScheme(scheme: SecurityScheme): AuthConfig {
+function convertSecurityScheme(scheme: SecurityScheme, requiredScopes: string[] = []): AuthConfig {
   // OpenAPI 3.x "http" type
   if (scheme.type === 'http') {
     if (scheme.scheme?.toLowerCase() === 'basic') {
@@ -1218,8 +1219,13 @@ function convertSecurityScheme(scheme: SecurityScheme): AuthConfig {
 
   // OAuth2 — map to OAuth 2.0 auth config with flow details
   // Prefer authorizationCode (more complete: has both authUrl + tokenUrl)
+  // Use operation-level required scopes when available; fall back to all flow scopes
   if (scheme.type === 'oauth2') {
     const flows = scheme.flows;
+    const scopeStr = (flow: OAuthFlow | undefined) =>
+      requiredScopes.length > 0
+        ? requiredScopes.join(' ')
+        : flow?.scopes ? Object.keys(flow.scopes).join(' ') : '';
     if (flows?.authorizationCode) {
       return {
         type: 'oauth2',
@@ -1229,7 +1235,7 @@ function convertSecurityScheme(scheme: SecurityScheme): AuthConfig {
           tokenUrl: flows.authorizationCode.tokenUrl || '',
           clientId: '',
           clientSecret: '',
-          scope: flows.authorizationCode.scopes ? Object.keys(flows.authorizationCode.scopes).join(' ') : '',
+          scope: scopeStr(flows.authorizationCode),
           callbackUrl: '',
         },
       };
@@ -1243,7 +1249,7 @@ function convertSecurityScheme(scheme: SecurityScheme): AuthConfig {
           tokenUrl: flows.clientCredentials.tokenUrl || '',
           clientId: '',
           clientSecret: '',
-          scope: flows.clientCredentials.scopes ? Object.keys(flows.clientCredentials.scopes).join(' ') : '',
+          scope: scopeStr(flows.clientCredentials),
           callbackUrl: '',
         },
       };

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1217,22 +1217,9 @@ function convertSecurityScheme(scheme: SecurityScheme): AuthConfig {
   }
 
   // OAuth2 — map to OAuth 2.0 auth config with flow details
+  // Prefer authorizationCode (more complete: has both authUrl + tokenUrl)
   if (scheme.type === 'oauth2') {
     const flows = scheme.flows;
-    if (flows?.clientCredentials) {
-      return {
-        type: 'oauth2',
-        oauth2: {
-          grantType: 'client_credentials',
-          authUrl: '',
-          tokenUrl: flows.clientCredentials.tokenUrl || '',
-          clientId: '',
-          clientSecret: '',
-          scope: flows.clientCredentials.scopes ? Object.keys(flows.clientCredentials.scopes).join(' ') : '',
-          callbackUrl: '',
-        },
-      };
-    }
     if (flows?.authorizationCode) {
       return {
         type: 'oauth2',
@@ -1243,6 +1230,20 @@ function convertSecurityScheme(scheme: SecurityScheme): AuthConfig {
           clientId: '',
           clientSecret: '',
           scope: flows.authorizationCode.scopes ? Object.keys(flows.authorizationCode.scopes).join(' ') : '',
+          callbackUrl: '',
+        },
+      };
+    }
+    if (flows?.clientCredentials) {
+      return {
+        type: 'oauth2',
+        oauth2: {
+          grantType: 'client_credentials',
+          authUrl: '',
+          tokenUrl: flows.clientCredentials.tokenUrl || '',
+          clientId: '',
+          clientSecret: '',
+          scope: flows.clientCredentials.scopes ? Object.keys(flows.clientCredentials.scopes).join(' ') : '',
           callbackUrl: '',
         },
       };

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1216,8 +1216,38 @@ function convertSecurityScheme(scheme: SecurityScheme): AuthConfig {
     };
   }
 
-  // OAuth2 — map to bearer since we can't do the flow
+  // OAuth2 — map to OAuth 2.0 auth config with flow details
   if (scheme.type === 'oauth2') {
+    const flows = scheme.flows;
+    if (flows?.clientCredentials) {
+      return {
+        type: 'oauth2',
+        oauth2: {
+          grantType: 'client_credentials',
+          authUrl: '',
+          tokenUrl: flows.clientCredentials.tokenUrl || '',
+          clientId: '',
+          clientSecret: '',
+          scope: flows.clientCredentials.scopes ? Object.keys(flows.clientCredentials.scopes).join(' ') : '',
+          callbackUrl: '',
+        },
+      };
+    }
+    if (flows?.authorizationCode) {
+      return {
+        type: 'oauth2',
+        oauth2: {
+          grantType: 'authorization_code',
+          authUrl: flows.authorizationCode.authorizationUrl || '',
+          tokenUrl: flows.authorizationCode.tokenUrl || '',
+          clientId: '',
+          clientSecret: '',
+          scope: flows.authorizationCode.scopes ? Object.keys(flows.authorizationCode.scopes).join(' ') : '',
+          callbackUrl: '',
+        },
+      };
+    }
+    // Fallback for implicit/password flows — use bearer as placeholder
     return { type: 'bearer', bearer: { token: '' } };
   }
 

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -223,6 +223,9 @@ interface SecurityScheme {
   bearerFormat?: string;
   flow?: string;                   // Swagger 2.0
   flows?: OAuthFlows;              // OpenAPI 3.x
+  authorizationUrl?: string;       // Swagger 2.0 (flat on scheme)
+  tokenUrl?: string;               // Swagger 2.0 (flat on scheme)
+  scopes?: Record<string, string>; // Swagger 2.0 (flat on scheme)
   openIdConnectUrl?: string;
 }
 
@@ -1256,6 +1259,41 @@ function convertSecurityScheme(scheme: SecurityScheme, requiredScopes?: string[]
           callbackUrl: '',
         },
       };
+    }
+    // Swagger 2.0: OAuth2 fields are flat on the scheme (flow, authorizationUrl, tokenUrl, scopes)
+    if (scheme.flow) {
+      const swagger2Scope = requiredScopes !== undefined
+        ? requiredScopes.join(' ')
+        : scheme.scopes ? Object.keys(scheme.scopes).join(' ') : '';
+      // Swagger 2.0 "accessCode" = authorization_code, "application" = client_credentials
+      if (scheme.flow === 'accessCode') {
+        return {
+          type: 'oauth2',
+          oauth2: {
+            grantType: 'authorization_code',
+            authUrl: scheme.authorizationUrl || '',
+            tokenUrl: scheme.tokenUrl || '',
+            clientId: '',
+            clientSecret: '',
+            scope: swagger2Scope,
+            callbackUrl: '',
+          },
+        };
+      }
+      if (scheme.flow === 'application') {
+        return {
+          type: 'oauth2',
+          oauth2: {
+            grantType: 'client_credentials',
+            authUrl: '',
+            tokenUrl: scheme.tokenUrl || '',
+            clientId: '',
+            clientSecret: '',
+            scope: swagger2Scope,
+            callbackUrl: '',
+          },
+        };
+      }
     }
     // Fallback for implicit/password flows — use bearer as placeholder
     return { type: 'bearer', bearer: { token: '' } };

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1180,14 +1180,14 @@ function extractAuth(spec: OpenApiSpec, operation: Operation): AuthConfig {
     if (!rawScheme) continue;
 
     const scheme = resolveSecuritySchemeRef(spec, rawScheme as SecuritySchemeOrRef);
-    const requiredScopes = req[schemeName] || [];
+    const requiredScopes = req[schemeName]; // undefined if absent, [] if explicitly empty
     return convertSecurityScheme(scheme, requiredScopes);
   }
 
   return { type: 'none' };
 }
 
-function convertSecurityScheme(scheme: SecurityScheme, requiredScopes: string[] = []): AuthConfig {
+function convertSecurityScheme(scheme: SecurityScheme, requiredScopes?: string[]): AuthConfig {
   // OpenAPI 3.x "http" type
   if (scheme.type === 'http') {
     if (scheme.scheme?.toLowerCase() === 'basic') {
@@ -1222,8 +1222,11 @@ function convertSecurityScheme(scheme: SecurityScheme, requiredScopes: string[] 
   // Use operation-level required scopes when available; fall back to all flow scopes
   if (scheme.type === 'oauth2') {
     const flows = scheme.flows;
+    // undefined = no operation scopes specified, use all flow scopes
+    // [] = operation explicitly requires no scopes, use empty string
+    // ['read'] = operation requires specific scopes
     const scopeStr = (flow: OAuthFlow | undefined) =>
-      requiredScopes.length > 0
+      requiredScopes !== undefined
         ? requiredScopes.join(' ')
         : flow?.scopes ? Object.keys(flow.scopes).join(' ') : '';
     if (flows?.authorizationCode) {

--- a/src/utils/postman.ts
+++ b/src/utils/postman.ts
@@ -77,6 +77,7 @@ interface PostmanAuth {
   basic?: PostmanAuthAttr[];
   bearer?: PostmanAuthAttr[];
   apikey?: PostmanAuthAttr[];
+  oauth2?: PostmanAuthAttr[];
 }
 
 interface PostmanAuthAttr {
@@ -306,13 +307,16 @@ function convertAuth(auth?: PostmanAuth): AuthConfig {
           addTo: getAuthAttr(auth.apikey, 'in') === 'query' ? 'query' : 'header',
         },
       };
-    case 'oauth2':
+    case 'oauth2': {
+      const grant = getAuthAttr(auth.oauth2, 'grant_type');
+      if (grant !== 'authorization_code' && grant !== 'client_credentials') {
+        // Unsupported OAuth2 grant type (implicit, password, etc.) — import as no auth
+        return { type: 'none' };
+      }
       return {
         type: 'oauth2',
         oauth2: {
-          grantType: getAuthAttr(auth.oauth2, 'grant_type') === 'authorization_code'
-            ? 'authorization_code'
-            : 'client_credentials',
+          grantType: grant,
           authUrl: getAuthAttr(auth.oauth2, 'authUrl'),
           tokenUrl: getAuthAttr(auth.oauth2, 'accessTokenUrl'),
           clientId: getAuthAttr(auth.oauth2, 'clientId'),
@@ -321,6 +325,7 @@ function convertAuth(auth?: PostmanAuth): AuthConfig {
           callbackUrl: getAuthAttr(auth.oauth2, 'redirect_uri'),
         },
       };
+    }
     default:
       // Unsupported auth types (oauth1, digest, etc.) — import as no auth
       return { type: 'none' };

--- a/src/utils/postman.ts
+++ b/src/utils/postman.ts
@@ -306,8 +306,23 @@ function convertAuth(auth?: PostmanAuth): AuthConfig {
           addTo: getAuthAttr(auth.apikey, 'in') === 'query' ? 'query' : 'header',
         },
       };
+    case 'oauth2':
+      return {
+        type: 'oauth2',
+        oauth2: {
+          grantType: getAuthAttr(auth.oauth2, 'grant_type') === 'authorization_code'
+            ? 'authorization_code'
+            : 'client_credentials',
+          authUrl: getAuthAttr(auth.oauth2, 'authUrl'),
+          tokenUrl: getAuthAttr(auth.oauth2, 'accessTokenUrl'),
+          clientId: getAuthAttr(auth.oauth2, 'clientId'),
+          clientSecret: getAuthAttr(auth.oauth2, 'clientSecret'),
+          scope: getAuthAttr(auth.oauth2, 'scope'),
+          callbackUrl: getAuthAttr(auth.oauth2, 'redirect_uri'),
+        },
+      };
     default:
-      // Unsupported auth types (oauth1, oauth2, digest, etc.) — import as no auth
+      // Unsupported auth types (oauth1, digest, etc.) — import as no auth
       return { type: 'none' };
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api/proxy': {
+      '/api': {
         target: 'http://localhost:3001',
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary
- Adds OAuth 2.0 auth type with **client credentials** and **authorization code** grant flows
- New token exchange proxy endpoint (`/api/oauth/token`) to avoid CORS issues with token endpoints
- Full auth UI: grant type selector, config fields, token status indicator (active/expired), get/refresh/clear token buttons
- Updates OpenAPI and Postman importers to map OAuth2 schemes to the new auth type
- Environment variable substitution works in all OAuth config fields
- **SSL verification toggle** — per-request shield icon in the URL bar to disable certificate checks (like Postman's "SSL verification" setting), using undici `Agent` with `rejectUnauthorized: false`

## Test plan
- [ ] Test client credentials flow against a real OAuth provider (e.g. Auth0)
- [ ] Test authorization code flow end-to-end
- [ ] Verify token status indicator shows green (active) and red (expired)
- [ ] Verify "Clear Token" removes stored token
- [ ] Import an OpenAPI spec with OAuth2 security scheme and confirm auth config is pre-filled
- [ ] Import a Postman collection with OAuth2 auth
- [ ] Verify `Authorization: Bearer <token>` header is sent on requests
- [ ] Toggle SSL verification off and hit a server with an untrusted cert — request should succeed
- [ ] Toggle SSL verification back on — same request should fail with certificate error
- [ ] All 344 unit tests pass