### PR TITLE
Add pre-request scripts, post-response tests, and request chaining

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -46,9 +46,9 @@
 - [x] GraphQL mode with query/variables editor and schema introspection
 - [x] OAuth 2.0 authentication flow (authorization code, client credentials)
 - [x] SSL certificate verification toggle (disable per-request, like Postman's "SSL verification" setting)
-- [ ] Pre-request scripts (JavaScript, runs before send)
-- [ ] Post-response tests (assertions on status, body, headers)
-- [ ] Request chaining -- use values from one response in the next request
+- [x] Pre-request scripts (JavaScript, runs before send)
+- [x] Post-response tests (assertions on status, body, headers)
+- [x] Request chaining -- use values from one response in the next request
 - [ ] WebSocket support
 
 ### v1.3 -- Collaboration & Sync

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -210,8 +210,10 @@ function App() {
               {/* Response panel */}
               <div className="flex-1 overflow-hidden">
                 <ResponsePanel
+                  key={activeRequest.id}
                   response={activeResponse ?? null}
                   loading={!!activeLoading}
+                  requestId={activeRequest.id}
                 />
               </div>
             </>

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -3,6 +3,7 @@ import CodeMirror from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
 import { xml } from '@codemirror/lang-xml';
 import { html } from '@codemirror/lang-html';
+import { javascript } from '@codemirror/lang-javascript';
 import { oneDark } from '@codemirror/theme-one-dark';
 import type { RequestConfig, BodyType, AuthType, OAuth2GrantType } from '../types';
 import { useAppStore } from '../store';
@@ -14,7 +15,7 @@ import { GraphQLEditor } from './GraphQLEditor';
 import { fetchOAuth2Token, buildAuthorizationUrl, isTokenExpired } from '../utils/oauth';
 import { resolveOAuth2Variables } from '../utils/http';
 
-type RequestTabType = 'params' | 'headers' | 'body' | 'auth';
+type RequestTabType = 'params' | 'headers' | 'body' | 'auth' | 'scripts';
 
 interface Props {
   request: RequestConfig;
@@ -24,11 +25,13 @@ export function RequestPanel({ request }: Props) {
   const [activeTab, setActiveTab] = useState<RequestTabType>('params');
   const updateRequest = useAppStore(s => s.updateRequest);
 
+  const hasScripts = !!(request.preRequestScript?.trim() || request.testScript?.trim());
   const tabs: { id: RequestTabType; label: string; count?: number }[] = [
     { id: 'params', label: 'Params', count: request.params.filter(p => p.enabled && p.key).length },
     { id: 'headers', label: 'Headers', count: request.headers.filter(h => h.enabled && h.key).length },
     { id: 'body', label: 'Body' },
     { id: 'auth', label: 'Auth' },
+    { id: 'scripts', label: 'Scripts', count: hasScripts ? 1 : undefined },
   ];
 
   return (
@@ -82,6 +85,10 @@ export function RequestPanel({ request }: Props) {
 
         {activeTab === 'auth' && (
           <AuthEditor request={request} />
+        )}
+
+        {activeTab === 'scripts' && (
+          <ScriptsEditor request={request} />
         )}
       </div>
     </div>
@@ -622,6 +629,150 @@ function AuthEditor({ request }: { request: RequestConfig }) {
                 Clear Token
               </button>
             )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+type ScriptSubTab = 'pre-request' | 'tests';
+
+const PRE_REQUEST_SNIPPETS = [
+  { label: 'Set header', code: `curlit.request.headers['X-Custom'] = 'value';` },
+  { label: 'Set chain variable', code: `curlit.chain.myVar = 'value';` },
+  { label: 'Log request', code: `console.log('Sending:', curlit.request.method, curlit.request.url);` },
+  { label: 'Add timestamp', code: `curlit.request.headers['X-Timestamp'] = Date.now().toString();` },
+];
+
+const TEST_SNIPPETS = [
+  { label: 'Status is 200', code: `test('Status is 200', () => {\n  expect(response.status).toBe(200);\n});` },
+  { label: 'Response has JSON', code: `test('Response is JSON', () => {\n  expect(response.json).toBeTruthy();\n});` },
+  { label: 'Save to chain', code: `// Save a value from response for use in other requests\ncurlit.chain.token = response.json.token;` },
+  { label: 'Check header', code: `test('Has content-type', () => {\n  expect(response.headers['content-type']).toContain('application/json');\n});` },
+  { label: 'Response time', code: `test('Response time < 500ms', () => {\n  expect(response.time).toBeLessThan(500);\n});` },
+];
+
+function ScriptsEditor({ request }: { request: RequestConfig }) {
+  const [subTab, setSubTab] = useState<ScriptSubTab>('pre-request');
+  const updateRequest = useAppStore(s => s.updateRequest);
+  const chainVariables = useAppStore(s => s.chainVariables);
+  const clearChainVariables = useAppStore(s => s.clearChainVariables);
+  const theme = useAppStore(s => s.theme) as Theme;
+
+  const snippets = subTab === 'pre-request' ? PRE_REQUEST_SNIPPETS : TEST_SNIPPETS;
+  const currentScript = subTab === 'pre-request' ? (request.preRequestScript ?? '') : (request.testScript ?? '');
+
+  const handleChange = (value: string) => {
+    if (subTab === 'pre-request') {
+      updateRequest(request.id, { preRequestScript: value });
+    } else {
+      updateRequest(request.id, { testScript: value });
+    }
+  };
+
+  const insertSnippet = (code: string) => {
+    const newScript = currentScript ? `${currentScript}\n\n${code}` : code;
+    handleChange(newScript);
+  };
+
+  const chainEntries = Object.entries(chainVariables);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Sub-tab selector */}
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => setSubTab('pre-request')}
+          className={`px-3 py-1.5 text-xs rounded-md font-medium transition-colors cursor-pointer ${
+            subTab === 'pre-request'
+              ? 'bg-accent-blue text-white'
+              : 'bg-dark-700 text-dark-300 hover:text-dark-100'
+          }`}
+        >
+          Pre-request
+          {request.preRequestScript?.trim() && (
+            <span className="ml-1 w-1.5 h-1.5 bg-accent-green rounded-full inline-block" />
+          )}
+        </button>
+        <button
+          onClick={() => setSubTab('tests')}
+          className={`px-3 py-1.5 text-xs rounded-md font-medium transition-colors cursor-pointer ${
+            subTab === 'tests'
+              ? 'bg-accent-blue text-white'
+              : 'bg-dark-700 text-dark-300 hover:text-dark-100'
+          }`}
+        >
+          Tests
+          {request.testScript?.trim() && (
+            <span className="ml-1 w-1.5 h-1.5 bg-accent-green rounded-full inline-block" />
+          )}
+        </button>
+      </div>
+
+      {/* Description */}
+      <div className="text-xs text-dark-400">
+        {subTab === 'pre-request'
+          ? 'JavaScript that runs before the request is sent. Access the request via curlit.request and chain variables via curlit.chain.'
+          : 'JavaScript that runs after receiving the response. Use test(name, fn) and expect() for assertions. Save values via curlit.chain for request chaining.'}
+      </div>
+
+      {/* Snippet buttons */}
+      <div className="flex items-center gap-1 flex-wrap">
+        <span className="text-[10px] text-dark-400 mr-1">Snippets:</span>
+        {snippets.map(s => (
+          <button
+            key={s.label}
+            onClick={() => insertSnippet(s.code)}
+            className="px-2 py-1 text-[10px] rounded bg-dark-700 text-dark-300 hover:text-dark-100 hover:bg-dark-600 transition-colors cursor-pointer"
+          >
+            {s.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Code editor */}
+      <div className="border border-dark-600 rounded-lg overflow-hidden h-[200px]">
+        <CodeMirror
+          value={currentScript}
+          onChange={handleChange}
+          extensions={[javascript()]}
+          theme={theme === 'dark' ? oneDark : 'light'}
+          height="200px"
+          placeholder={subTab === 'pre-request'
+            ? '// Modify request before sending\ncurlit.request.headers[\'X-Custom\'] = \'value\';'
+            : '// Write tests for the response\ntest(\'Status is 200\', () => {\n  expect(response.status).toBe(200);\n});'}
+          basicSetup={{
+            lineNumbers: true,
+            foldGutter: true,
+            bracketMatching: true,
+            closeBrackets: true,
+            autocompletion: true,
+          }}
+        />
+      </div>
+
+      {/* Chain variables display */}
+      {chainEntries.length > 0 && (
+        <div className="border border-dark-600 rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-3 py-1.5 bg-dark-700 border-b border-dark-600">
+            <span className="text-[10px] font-medium text-dark-300 uppercase tracking-wide">
+              Chain Variables ({chainEntries.length})
+            </span>
+            <button
+              onClick={clearChainVariables}
+              className="text-[10px] text-dark-400 hover:text-accent-red transition-colors cursor-pointer"
+            >
+              Clear All
+            </button>
+          </div>
+          <div className="max-h-[100px] overflow-auto">
+            {chainEntries.map(([key, value]) => (
+              <div key={key} className="flex items-center px-3 py-1 border-b border-dark-700 last:border-0">
+                <span className="text-[11px] font-mono text-accent-blue mr-2 shrink-0">{`{{chain.${key}}}`}</span>
+                <span className="text-[11px] font-mono text-dark-200 truncate">{value}</span>
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/src/components/ResponsePanel.tsx
+++ b/src/components/ResponsePanel.tsx
@@ -5,7 +5,7 @@ import { xml } from '@codemirror/lang-xml';
 import { html } from '@codemirror/lang-html';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { search, openSearchPanel } from '@codemirror/search';
-import { Copy, Check, FileDown, Search } from 'lucide-react';
+import { Copy, Check, FileDown, Search, CircleCheck, CircleX, Terminal } from 'lucide-react';
 import type { ResponseData } from '../types';
 import { getStatusColor, formatBytes, formatTime, tryFormatJson } from '../utils/http';
 import { useAppStore } from '../store';
@@ -13,16 +13,29 @@ import { useAppStore } from '../store';
 interface Props {
   response: ResponseData | null;
   loading: boolean;
+  requestId: string;
 }
 
-type ResponseTab = 'body' | 'headers' | 'cookies';
+type ResponseTab = 'body' | 'headers' | 'cookies' | 'tests' | 'console';
 
-export function ResponsePanel({ response, loading }: Props) {
+export function ResponsePanel({ response, loading, requestId }: Props) {
   const [activeTab, setActiveTab] = useState<ResponseTab>('body');
   const [copied, setCopied] = useState(false);
   const [bodyFormat, setBodyFormat] = useState<'pretty' | 'raw'>('pretty');
   const theme = useAppStore(s => s.theme);
   const editorRef = useRef<ReactCodeMirrorRef>(null);
+  const testResults = useAppStore(s => s.testResults[requestId]);
+  const scriptLogs = useAppStore(s => s.scriptLogs[requestId]);
+
+  // Derive effective tab: fall back to 'body' if selected tab's data is gone.
+  // The parent component uses key={requestId} to remount this component when
+  // the request changes, which resets activeTab to 'body' automatically.
+  const testsAvailable = (testResults ?? []).length > 0;
+  const logsAvailable = (scriptLogs ?? []).length > 0;
+  const effectiveTab =
+    (activeTab === 'tests' && !testsAvailable) ? 'body' :
+    (activeTab === 'console' && !logsAvailable) ? 'body' :
+    activeTab;
 
   const handleSearch = useCallback(() => {
     const view = editorRef.current?.view;
@@ -96,10 +109,26 @@ export function ResponsePanel({ response, loading }: Props) {
     URL.revokeObjectURL(url);
   };
 
-  const tabs: { id: ResponseTab; label: string; count?: number }[] = [
+  const tests = testResults ?? [];
+  const logs = scriptLogs ?? [];
+  const passedTests = tests.filter(t => t.passed).length;
+  const failedTests = tests.filter(t => !t.passed).length;
+
+  const tabs: { id: ResponseTab; label: string; count?: number; color?: string }[] = [
     { id: 'body', label: 'Body' },
     { id: 'headers', label: 'Headers', count: Object.keys(response.headers).length },
     { id: 'cookies', label: 'Cookies', count: response.cookies.length },
+    ...(tests.length > 0 ? [{
+      id: 'tests' as const,
+      label: 'Tests',
+      count: tests.length,
+      color: failedTests > 0 ? 'text-accent-red' : 'text-accent-green',
+    }] : []),
+    ...(logs.length > 0 ? [{
+      id: 'console' as const,
+      label: 'Console',
+      count: logs.length,
+    }] : []),
   ];
 
   return (
@@ -113,14 +142,14 @@ export function ResponsePanel({ response, loading }: Props) {
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
               className={`text-sm font-medium transition-colors cursor-pointer ${
-                activeTab === tab.id
+                effectiveTab === tab.id
                   ? 'text-dark-100 border-b-2 border-accent-blue pb-1'
                   : 'text-dark-300 hover:text-dark-200'
               }`}
             >
               {tab.label}
               {tab.count !== undefined && tab.count > 0 && (
-                <span className="ml-1 text-[10px] text-dark-400">({tab.count})</span>
+                <span className={`ml-1 text-[10px] ${tab.color || 'text-dark-400'}`}>({tab.count})</span>
               )}
             </button>
           ))}
@@ -139,7 +168,7 @@ export function ResponsePanel({ response, loading }: Props) {
 
       {/* Tab content */}
       <div className="flex-1 overflow-hidden">
-        {activeTab === 'body' && (
+        {effectiveTab === 'body' && (
           <div className="flex flex-col h-full">
             {/* Body toolbar */}
             <div className="flex items-center justify-between px-3 py-1.5 border-b border-dark-700">
@@ -227,7 +256,7 @@ export function ResponsePanel({ response, loading }: Props) {
           </div>
         )}
 
-        {activeTab === 'headers' && (
+        {effectiveTab === 'headers' && (
           <div className="overflow-auto p-3">
             <table className="w-full text-sm">
               <thead>
@@ -251,7 +280,7 @@ export function ResponsePanel({ response, loading }: Props) {
           </div>
         )}
 
-        {activeTab === 'cookies' && (
+        {effectiveTab === 'cookies' && (
           <div className="overflow-auto p-3">
             <table className="w-full text-sm">
               <thead>
@@ -275,6 +304,81 @@ export function ResponsePanel({ response, loading }: Props) {
             </table>
             {response.cookies.length === 0 && (
               <div className="text-dark-400 text-sm text-center py-8">No cookies in response</div>
+            )}
+          </div>
+        )}
+
+        {effectiveTab === 'tests' && (
+          <div className="overflow-auto p-3">
+            {/* Summary bar */}
+            <div className="flex items-center gap-4 mb-3 px-2 py-2 bg-dark-800 rounded-lg">
+              <span className="text-xs font-medium text-dark-300">
+                {tests.length} test{tests.length !== 1 ? 's' : ''}
+              </span>
+              {passedTests > 0 && (
+                <span className="flex items-center gap-1 text-xs text-accent-green">
+                  <CircleCheck size={12} /> {passedTests} passed
+                </span>
+              )}
+              {failedTests > 0 && (
+                <span className="flex items-center gap-1 text-xs text-accent-red">
+                  <CircleX size={12} /> {failedTests} failed
+                </span>
+              )}
+            </div>
+
+            {/* Test list */}
+            <div className="flex flex-col gap-1">
+              {tests.map((t, i) => (
+                <div
+                  key={i}
+                  className={`flex items-start gap-2 px-3 py-2 rounded-lg border ${
+                    t.passed
+                      ? 'bg-accent-green/5 border-accent-green/20'
+                      : 'bg-accent-red/5 border-accent-red/20'
+                  }`}
+                >
+                  {t.passed ? (
+                    <CircleCheck size={14} className="text-accent-green mt-0.5 shrink-0" />
+                  ) : (
+                    <CircleX size={14} className="text-accent-red mt-0.5 shrink-0" />
+                  )}
+                  <div className="flex flex-col gap-0.5">
+                    <span className={`text-xs font-medium ${t.passed ? 'text-accent-green' : 'text-accent-red'}`}>
+                      {t.name}
+                    </span>
+                    {t.error && (
+                      <span className="text-[11px] text-dark-300 font-mono">{t.error}</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {effectiveTab === 'console' && (
+          <div className="overflow-auto p-3">
+            <div className="flex flex-col gap-0.5 font-mono text-xs">
+              {logs.map((entry, i) => (
+                <div
+                  key={i}
+                  className={`flex items-start gap-2 px-2 py-1 rounded ${
+                    entry.type === 'error' ? 'bg-accent-red/10 text-accent-red' :
+                    entry.type === 'warn' ? 'bg-accent-yellow/10 text-accent-yellow' :
+                    entry.type === 'info' ? 'text-accent-blue' :
+                    'text-dark-200'
+                  }`}
+                >
+                  <Terminal size={12} className="mt-0.5 shrink-0 opacity-50" />
+                  <span className="whitespace-pre-wrap break-all">
+                    {entry.args.map(a => typeof a === 'string' ? a : JSON.stringify(a, null, 2)).join(' ')}
+                  </span>
+                </div>
+              ))}
+            </div>
+            {logs.length === 0 && (
+              <div className="text-dark-400 text-sm text-center py-8">No console output</div>
             )}
           </div>
         )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,9 +14,21 @@ import {
 import { useAppStore, type SidebarView } from '../store';
 import { MethodBadge } from './MethodBadge';
 import { KeyValueEditor } from './KeyValueEditor';
-import type { Collection } from '../types';
+import type { Collection, RequestConfig } from '../types';
 import { isPostmanCollection, parsePostmanCollection } from '../utils/postman';
 import { parseOpenApiInput, isOpenApiSpec, parseOpenApiSpec } from '../utils/openapi';
+
+/** Strip scripts from imported requests to prevent code execution from untrusted collections. */
+function stripScripts(request: RequestConfig): RequestConfig {
+  const cleaned = { ...request };
+  delete cleaned.preRequestScript;
+  delete cleaned.testScript;
+  return cleaned;
+}
+
+function stripScriptsFromCollection(collection: Collection): Collection {
+  return { ...collection, requests: collection.requests.map(stripScripts) };
+}
 
 export function Sidebar() {
   const sidebarView = useAppStore(s => s.sidebarView);
@@ -98,14 +110,16 @@ function CollectionsPanel() {
         useAppStore.getState().createCollection(name);
         const newCollection = useAppStore.getState().collections[useAppStore.getState().collections.length - 1];
         requests.forEach(r => {
-          useAppStore.getState().saveRequestToCollection(newCollection.id, r);
+          useAppStore.getState().saveRequestToCollection(newCollection.id, stripScripts(r));
         });
       } else if (data.collections && Array.isArray(data.collections)) {
-        // CurlIt native format
+        // CurlIt native format — strip scripts from imported requests to
+        // prevent untrusted collections from executing arbitrary code.
         data.collections.forEach((c: Collection) => {
-          useAppStore.getState().createCollection(c.name);
+          const safe = stripScriptsFromCollection(c);
+          useAppStore.getState().createCollection(safe.name);
           const newCollection = useAppStore.getState().collections[useAppStore.getState().collections.length - 1];
-          c.requests.forEach(r => {
+          safe.requests.forEach(r => {
             useAppStore.getState().saveRequestToCollection(newCollection.id, r);
           });
         });

--- a/src/components/UrlBar.tsx
+++ b/src/components/UrlBar.tsx
@@ -1,8 +1,9 @@
 import { Send, Loader2, ShieldCheck, ShieldOff } from 'lucide-react';
 import type { HttpMethod, RequestConfig } from '../types';
 import { useAppStore } from '../store';
-import { sendRequest, resolveRequestVariables } from '../utils/http';
+import { sendRequest, resolveRequestVariables, buildHeaders, buildBody } from '../utils/http';
 import { getMethodColor } from '../utils/http';
+import { runPreRequestScript, runTestScript } from '../utils/scriptEngine';
 
 const METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
 
@@ -16,6 +17,10 @@ export function UrlBar({ request }: Props) {
   const setLoading = useAppStore(s => s.setLoading);
   const addToHistory = useAppStore(s => s.addToHistory);
   const getActiveVariables = useAppStore(s => s.getActiveVariables);
+  const getChainVariables = useAppStore(s => s.getChainVariables);
+  const updateChainVariables = useAppStore(s => s.updateChainVariables);
+  const setTestResults = useAppStore(s => s.setTestResults);
+  const setScriptLogs = useAppStore(s => s.setScriptLogs);
   const loading = useAppStore(s => s.loadingRequests[request.id]);
 
   const handleSend = async () => {
@@ -23,13 +28,130 @@ export function UrlBar({ request }: Props) {
 
     setLoading(request.id, true);
     setResponse(request.id, null);
+    setTestResults(request.id, []);
+    setScriptLogs(request.id, []);
 
     try {
       const variables = getActiveVariables();
-      const resolved = resolveRequestVariables(request, variables);
+      const chainVars = getChainVariables();
+      let resolved = resolveRequestVariables(request, variables, chainVars);
+      let allLogs: import('../types').ScriptConsoleEntry[] = [];
+
+      // --- Pre-request script ---
+      if (request.preRequestScript?.trim()) {
+        const headers = buildHeaders(resolved.headers, resolved.auth);
+        const body = buildBody(resolved);
+        const bodyStr = body === null ? null : typeof body === 'string' ? body : null;
+
+        const preResult = runPreRequestScript(
+          request.preRequestScript,
+          resolved,
+          headers,
+          bodyStr,
+          variables,
+          chainVars,
+        );
+        allLogs = [...allLogs, ...preResult.logs];
+
+        if (preResult.error) {
+          setScriptLogs(request.id, allLogs);
+          setResponse(request.id, {
+            status: 0,
+            statusText: 'Script Error',
+            headers: {},
+            body: `Pre-request script error: ${preResult.error}`,
+            size: 0,
+            time: 0,
+            cookies: [],
+          });
+          setLoading(request.id, false);
+          return;
+        }
+
+        // Apply mutations from pre-request script.
+        // The script received fully-built headers (auth already baked in),
+        // so we neutralize header-based auth to prevent sendRequest from
+        // re-applying auth headers on top of whatever the script set.
+        // We preserve query-style API-key auth because sendRequest appends
+        // those to the URL — they aren't in the headers the script saw.
+        updateChainVariables(preResult.chain);
+        const isQueryApiKey = resolved.auth.type === 'api-key'
+          && resolved.auth.apiKey?.addTo === 'query';
+        resolved = {
+          ...resolved,
+          method: (preResult.request.method as RequestConfig['method']) || resolved.method,
+          url: preResult.request.url || resolved.url,
+          headers: Object.entries(preResult.request.headers).map(([key, value]) => ({
+            id: crypto.randomUUID(),
+            key,
+            value,
+            enabled: true,
+          })),
+          auth: isQueryApiKey ? resolved.auth : { type: 'none' },
+        };
+
+        // If the script changed the body, override with the raw string.
+        // Switch to body type 'text' so buildBody() reads .raw instead of
+        // rebuilding from structured fields (graphql, form-data, etc.).
+        // Also ensure Content-Type is preserved: the auto-header logic in
+        // sendRequest only fires for specific body types, so we inject the
+        // correct content-type into the resolved headers if the script
+        // didn't already set one.
+        if (preResult.request.body !== null && preResult.request.body !== bodyStr) {
+          const originalType = resolved.body.type;
+          resolved = {
+            ...resolved,
+            body: { ...resolved.body, type: 'text', raw: preResult.request.body },
+          };
+
+          // If the script's headers don't include Content-Type, carry over
+          // what sendRequest would have auto-set for the original body type.
+          const hasContentType = resolved.headers.some(
+            h => h.enabled && h.key.toLowerCase() === 'content-type',
+          );
+          if (!hasContentType) {
+            const autoType: Record<string, string> = {
+              json: 'application/json',
+              graphql: 'application/json',
+              xml: 'application/xml',
+              'x-www-form-urlencoded': 'application/x-www-form-urlencoded',
+            };
+            const ct = autoType[originalType];
+            if (ct) {
+              resolved = {
+                ...resolved,
+                headers: [
+                  ...resolved.headers,
+                  { id: crypto.randomUUID(), key: 'Content-Type', value: ct, enabled: true },
+                ],
+              };
+            }
+          }
+        }
+      }
+
       const response = await sendRequest(resolved);
       setResponse(request.id, response);
       addToHistory(request, response);
+
+      // --- Post-response test script ---
+      if (request.testScript?.trim() && response.status !== 0) {
+        const latestChain = useAppStore.getState().chainVariables;
+        const testResult = runTestScript(request.testScript, resolved, response, latestChain);
+        allLogs = [...allLogs, ...testResult.logs];
+        setTestResults(request.id, testResult.tests);
+        updateChainVariables(testResult.chain);
+
+        if (testResult.error) {
+          allLogs.push({
+            type: 'error',
+            args: [`Test script error: ${testResult.error}`],
+            timestamp: Date.now(),
+          });
+        }
+      }
+
+      setScriptLogs(request.id, allLogs);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to send request';
       const isProxyDown = message === 'Failed to fetch' || message.includes('NetworkError');

--- a/src/components/__tests__/ResponsePanel.test.tsx
+++ b/src/components/__tests__/ResponsePanel.test.tsx
@@ -5,12 +5,12 @@ import type { ResponseData } from '../../types';
 
 describe('ResponsePanel', () => {
   it('shows loading spinner when loading', () => {
-    render(<ResponsePanel response={null} loading={true} />);
+    render(<ResponsePanel response={null} loading={true} requestId="test-id" />);
     expect(screen.getByText('Sending request...')).toBeInTheDocument();
   });
 
   it('shows empty state when no response', () => {
-    render(<ResponsePanel response={null} loading={false} />);
+    render(<ResponsePanel response={null} loading={false} requestId="test-id" />);
     expect(screen.getByText(/Enter a URL and click Send/)).toBeInTheDocument();
   });
 
@@ -24,7 +24,7 @@ describe('ResponsePanel', () => {
       time: 150,
       cookies: [],
     };
-    render(<ResponsePanel response={response} loading={false} />);
+    render(<ResponsePanel response={response} loading={false} requestId="test-id" />);
     expect(screen.getByText(/200/)).toBeInTheDocument();
     expect(screen.getByText(/OK/)).toBeInTheDocument();
     expect(screen.getByText('150 ms')).toBeInTheDocument();

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,6 +7,8 @@ import type {
   Environment,
   Tab,
   HttpMethod,
+  TestResult,
+  ScriptConsoleEntry,
 } from '../types';
 import { createDefaultRequest } from '../types';
 import { removeFilesForRequest } from '../utils/fileStore';
@@ -17,6 +19,7 @@ const STORAGE_KEYS = {
   environments: 'curlit_environments',
   activeEnv: 'curlit_active_env',
   theme: 'curlit_theme',
+  chainVariables: 'curlit_chain_vars',
 };
 
 function loadFromStorage<T>(key: string, fallback: T): T {
@@ -59,6 +62,11 @@ interface AppState {
   environments: Environment[];
   activeEnvironmentId: string | null;
 
+  // Scripts & Tests
+  testResults: Record<string, TestResult[]>;
+  scriptLogs: Record<string, ScriptConsoleEntry[]>;
+  chainVariables: Record<string, string>;
+
   // UI
   theme: Theme;
   sidebarView: SidebarView;
@@ -95,6 +103,13 @@ interface AppState {
   setActiveEnvironment: (id: string | null) => void;
   getActiveVariables: () => Record<string, string>;
 
+  // Actions - Scripts & Tests
+  setTestResults: (requestId: string, results: TestResult[]) => void;
+  setScriptLogs: (requestId: string, logs: ScriptConsoleEntry[]) => void;
+  updateChainVariables: (vars: Record<string, string>) => void;
+  clearChainVariables: () => void;
+  getChainVariables: () => Record<string, string>;
+
   // Actions - Save
   saveActiveRequest: () => 'saved' | 'needs-collection';
   markTabSaved: (tabId: string, collectionId: string, sourceRequestId: string) => void;
@@ -127,6 +142,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   history: loadFromStorage<HistoryEntry[]>(STORAGE_KEYS.history, []),
   environments: loadFromStorage<Environment[]>(STORAGE_KEYS.environments, []),
   activeEnvironmentId: loadFromStorage<string | null>(STORAGE_KEYS.activeEnv, null),
+  testResults: {},
+  scriptLogs: {},
+  chainVariables: loadFromStorage<Record<string, string>>(STORAGE_KEYS.chainVariables, {}),
   theme: loadFromStorage<Theme>(STORAGE_KEYS.theme, 'dark'),
   sidebarView: 'collections',
   sidebarOpen: true,
@@ -427,6 +445,34 @@ export const useAppStore = create<AppState>((set, get) => ({
     });
     return vars;
   },
+
+  // Script & Test actions
+  setTestResults: (requestId, results) => {
+    set(state => ({
+      testResults: { ...state.testResults, [requestId]: results },
+    }));
+  },
+
+  setScriptLogs: (requestId, logs) => {
+    set(state => ({
+      scriptLogs: { ...state.scriptLogs, [requestId]: logs },
+    }));
+  },
+
+  updateChainVariables: (vars) => {
+    set(state => {
+      const chainVariables = { ...state.chainVariables, ...vars };
+      saveToStorage(STORAGE_KEYS.chainVariables, chainVariables);
+      return { chainVariables };
+    });
+  },
+
+  clearChainVariables: () => {
+    saveToStorage(STORAGE_KEYS.chainVariables, {});
+    set({ chainVariables: {} });
+  },
+
+  getChainVariables: () => get().chainVariables,
 
   // Save actions
   saveActiveRequest: () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,20 @@ export interface RequestConfig {
   };
   auth: AuthConfig;
   sslVerification?: boolean;
+  preRequestScript?: string;
+  testScript?: string;
+}
+
+export interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+export interface ScriptConsoleEntry {
+  type: 'log' | 'warn' | 'error' | 'info';
+  args: unknown[];
+  timestamp: number;
 }
 
 export interface ResponseData {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -111,49 +111,55 @@ export function buildBody(request: RequestConfig): string | FormData | File | nu
   }
 }
 
-export function resolveVariables(text: string, variables: Record<string, string>): string {
-  return text.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+export function resolveVariables(text: string, variables: Record<string, string>, chainVars?: Record<string, string>): string {
+  return text.replace(/\{\{([\w.]+)\}\}/g, (match, key: string) => {
+    // Support {{chain.varName}} for request chaining
+    if (key.startsWith('chain.') && chainVars) {
+      const chainKey = key.slice(6);
+      return chainVars[chainKey] ?? match;
+    }
     return variables[key] ?? match;
   });
 }
 
-export function resolveRequestVariables(request: RequestConfig, variables: Record<string, string>): RequestConfig {
+export function resolveRequestVariables(request: RequestConfig, variables: Record<string, string>, chainVars?: Record<string, string>): RequestConfig {
+  const rv = (text: string) => resolveVariables(text, variables, chainVars);
   return {
     ...request,
-    url: resolveVariables(request.url, variables),
+    url: rv(request.url),
     params: request.params.map(p => ({
       ...p,
-      key: resolveVariables(p.key, variables),
-      value: resolveVariables(p.value, variables),
+      key: rv(p.key),
+      value: rv(p.value),
     })),
     headers: request.headers.map(h => ({
       ...h,
-      key: resolveVariables(h.key, variables),
-      value: resolveVariables(h.value, variables),
+      key: rv(h.key),
+      value: rv(h.value),
     })),
     body: {
       ...request.body,
-      raw: resolveVariables(request.body.raw, variables),
+      raw: rv(request.body.raw),
       formData: request.body.formData.map(f => ({
         ...f,
-        key: resolveVariables(f.key, variables),
-        value: f.valueType === 'file' ? f.value : resolveVariables(f.value, variables),
+        key: rv(f.key),
+        value: f.valueType === 'file' ? f.value : rv(f.value),
       })),
       urlencoded: request.body.urlencoded.map(f => ({
         ...f,
-        key: resolveVariables(f.key, variables),
-        value: resolveVariables(f.value, variables),
+        key: rv(f.key),
+        value: rv(f.value),
       })),
       graphql: request.body.graphql ? {
-        query: resolveVariables(request.body.graphql.query, variables),
-        variables: resolveVariables(request.body.graphql.variables, variables),
+        query: rv(request.body.graphql.query),
+        variables: rv(request.body.graphql.variables),
         operationName: request.body.graphql.operationName
-          ? resolveVariables(request.body.graphql.operationName, variables) : undefined,
+          ? rv(request.body.graphql.operationName) : undefined,
         extensions: request.body.graphql.extensions
-          ? resolveVariables(request.body.graphql.extensions, variables) : undefined,
+          ? rv(request.body.graphql.extensions) : undefined,
       } : undefined,
     },
-    auth: resolveAuthVariables(request.auth, variables),
+    auth: resolveAuthVariables(request.auth, variables, chainVars),
   };
 }
 
@@ -173,22 +179,23 @@ export function resolveOAuth2Variables(
   };
 }
 
-function resolveAuthVariables(auth: AuthConfig, variables: Record<string, string>): AuthConfig {
+function resolveAuthVariables(auth: AuthConfig, variables: Record<string, string>, chainVars?: Record<string, string>): AuthConfig {
+  const rv = (text: string) => resolveVariables(text, variables, chainVars);
   const resolved = { ...auth };
   if (resolved.basic) {
     resolved.basic = {
-      username: resolveVariables(resolved.basic.username, variables),
-      password: resolveVariables(resolved.basic.password, variables),
+      username: rv(resolved.basic.username),
+      password: rv(resolved.basic.password),
     };
   }
   if (resolved.bearer) {
-    resolved.bearer = { token: resolveVariables(resolved.bearer.token, variables) };
+    resolved.bearer = { token: rv(resolved.bearer.token) };
   }
   if (resolved.apiKey) {
     resolved.apiKey = {
       ...resolved.apiKey,
-      key: resolveVariables(resolved.apiKey.key, variables),
-      value: resolveVariables(resolved.apiKey.value, variables),
+      key: rv(resolved.apiKey.key),
+      value: rv(resolved.apiKey.value),
     };
   }
   if (resolved.oauth2) {

--- a/src/utils/scriptEngine.ts
+++ b/src/utils/scriptEngine.ts
@@ -1,0 +1,398 @@
+import type { RequestConfig, ResponseData, TestResult, ScriptConsoleEntry } from '../types';
+
+// ---------------------------------------------------------------------------
+// Pre-request script context — can read & mutate the request before it's sent
+// ---------------------------------------------------------------------------
+export interface PreRequestContext {
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body: string | null;
+  };
+  variables: Record<string, string>;
+  chain: Record<string, string>;
+}
+
+export interface PreRequestResult {
+  request: PreRequestContext['request'];
+  variables: Record<string, string>;
+  chain: Record<string, string>;
+  logs: ScriptConsoleEntry[];
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Post-response (test) script context — read-only request + response, tests
+// ---------------------------------------------------------------------------
+export interface TestScriptResult {
+  tests: TestResult[];
+  chain: Record<string, string>;
+  logs: ScriptConsoleEntry[];
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Build a minimal console that captures output
+// ---------------------------------------------------------------------------
+function createConsoleCapture(): { console: Record<string, (...args: unknown[]) => void>; logs: ScriptConsoleEntry[] } {
+  const logs: ScriptConsoleEntry[] = [];
+  const makeLogger = (type: ScriptConsoleEntry['type']) => (...args: unknown[]) => {
+    logs.push({ type, args: args.map(serialize), timestamp: Date.now() });
+  };
+  return {
+    logs,
+    console: {
+      log: makeLogger('log'),
+      info: makeLogger('info'),
+      warn: makeLogger('warn'),
+      error: makeLogger('error'),
+    },
+  };
+}
+
+function serialize(val: unknown): unknown {
+  if (val === null || val === undefined) return val;
+  if (typeof val === 'object') {
+    try { return JSON.parse(JSON.stringify(val)); } catch { return String(val); }
+  }
+  return val;
+}
+
+// ---------------------------------------------------------------------------
+// Expect / assertion helpers injected into test scripts
+// ---------------------------------------------------------------------------
+function createExpect(value: unknown) {
+  const assert = (ok: boolean, msg: string) => {
+    if (!ok) throw new Error(msg);
+  };
+
+  const positiveAssertions = {
+    toBe(expected: unknown) {
+      assert(value === expected, `Expected ${JSON.stringify(value)} to be ${JSON.stringify(expected)}`);
+    },
+    toEqual(expected: unknown) {
+      assert(
+        JSON.stringify(value) === JSON.stringify(expected),
+        `Expected ${JSON.stringify(value)} to equal ${JSON.stringify(expected)}`,
+      );
+    },
+    toContain(item: unknown) {
+      if (typeof value === 'string') {
+        assert(value.includes(String(item)), `Expected "${value}" to contain "${item}"`);
+      } else if (Array.isArray(value)) {
+        assert(value.includes(item), `Expected array to contain ${JSON.stringify(item)}`);
+      } else {
+        throw new Error('toContain can only be used on strings or arrays');
+      }
+    },
+    toBeTruthy() {
+      assert(!!value, `Expected ${JSON.stringify(value)} to be truthy`);
+    },
+    toBeFalsy() {
+      assert(!value, `Expected ${JSON.stringify(value)} to be falsy`);
+    },
+    toBeGreaterThan(n: number) {
+      assert(Number(value) > n, `Expected ${value} to be greater than ${n}`);
+    },
+    toBeLessThan(n: number) {
+      assert(Number(value) < n, `Expected ${value} to be less than ${n}`);
+    },
+    toHaveProperty(key: string) {
+      assert(
+        value !== null && typeof value === 'object' && key in (value as Record<string, unknown>),
+        `Expected object to have property "${key}"`,
+      );
+    },
+    toMatch(pattern: RegExp | string) {
+      const re = pattern instanceof RegExp ? pattern : new RegExp(pattern);
+      assert(re.test(String(value)), `Expected "${value}" to match ${re}`);
+    },
+  };
+
+  return {
+    ...positiveAssertions,
+    not: {
+      toBe(expected: unknown) {
+        assert(value !== expected, `Expected ${JSON.stringify(value)} not to be ${JSON.stringify(expected)}`);
+      },
+      toEqual(expected: unknown) {
+        assert(
+          JSON.stringify(value) !== JSON.stringify(expected),
+          `Expected value not to equal ${JSON.stringify(expected)}`,
+        );
+      },
+      toContain(item: unknown) {
+        if (typeof value === 'string') {
+          assert(!value.includes(String(item)), `Expected "${value}" not to contain "${item}"`);
+        } else if (Array.isArray(value)) {
+          assert(!value.includes(item), `Expected array not to contain ${JSON.stringify(item)}`);
+        }
+      },
+      toBeTruthy() {
+        assert(!value, `Expected ${JSON.stringify(value)} not to be truthy`);
+      },
+      toBeFalsy() {
+        assert(!!value, `Expected ${JSON.stringify(value)} not to be falsy`);
+      },
+      toBeGreaterThan(n: number) {
+        assert(Number(value) <= n, `Expected ${value} not to be greater than ${n}`);
+      },
+      toBeLessThan(n: number) {
+        assert(Number(value) >= n, `Expected ${value} not to be less than ${n}`);
+      },
+      toHaveProperty(key: string) {
+        assert(
+          value === null || typeof value !== 'object' || !(key in (value as Record<string, unknown>)),
+          `Expected object not to have property "${key}"`,
+        );
+      },
+      toMatch(pattern: RegExp | string) {
+        const re = pattern instanceof RegExp ? pattern : new RegExp(pattern);
+        assert(!re.test(String(value)), `Expected "${value}" not to match ${re}`);
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Static validation — reject scripts that contain async constructs.
+//
+// The constructor-chain defense is only active during synchronous execution.
+// Async code (Promise microtasks, dynamic import, async/await) can outlive
+// the synchronous call and access restored constructors. Since pre-request
+// and test scripts have no legitimate need for async operations, we reject
+// them statically before execution.
+// ---------------------------------------------------------------------------
+/** Strip string literals, template literals, and comments so keyword checks
+ *  don't trigger on `console.log('await')` or `// async note`. */
+function stripStringsAndComments(code: string): string {
+  return code.replace(
+    /\/\/[^\n]*|\/\*[\s\S]*?\*\/|`(?:\\[\s\S]|[^`\\])*`|"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'/g,
+    '',
+  );
+}
+
+/** Patterns matched against code AFTER strings/comments are removed.
+ *  `async` only matches actual keyword positions: before `function`, `(`, `=>`,
+ *  or an arrow-param identifier. Property keys like `{async: true}` or
+ *  `obj.async` are not matched. */
+const ASYNC_PATTERNS: [RegExp, string][] = [
+  [/(?<!\.)\bimport\s*\(/, 'Dynamic import() is not allowed in scripts'],
+  [/(?<!\.)\basync\s+(?:function\b|\(|[a-zA-Z_$])/, 'Async functions are not allowed in scripts'],
+  [/(?<!\.)\bawait\s+/, 'await is not allowed in scripts'],
+];
+
+export function validateScript(code: string): string | null {
+  const stripped = stripStringsAndComments(code);
+  for (const [pattern, message] of ASYNC_PATTERNS) {
+    if (pattern.test(stripped)) return message;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Globals shadowed via outer Function parameters (set to undefined).
+// `eval` cannot be shadowed as a parameter in strict mode, so it is handled
+// separately via a sloppy-mode IIFE wrapper (see below).
+// ---------------------------------------------------------------------------
+const BLOCKED_GLOBALS = [
+  'window', 'self', 'globalThis', 'document',
+  'localStorage', 'sessionStorage', 'indexedDB',
+  'fetch', 'XMLHttpRequest', 'WebSocket', 'EventSource',
+  'importScripts', 'navigator', 'location', 'history',
+  'alert', 'confirm', 'prompt', 'open', 'close',
+  'postMessage', 'addEventListener', 'removeEventListener',
+  'setTimeout', 'setInterval', 'requestAnimationFrame',
+  'Function',
+  // Async primitives — defense-in-depth alongside static validation
+  'Promise', 'queueMicrotask', 'MutationObserver', 'MessageChannel',
+  'requestIdleCallback',
+];
+
+// ---------------------------------------------------------------------------
+// Run a script string inside a Function sandbox with blocked globals.
+//
+// Defence layers:
+// 1. Static validation rejects async/await/import() before execution
+// 2. Parameter-shadow browser APIs (window, fetch, document, Promise, …)
+// 3. Sloppy-mode IIFE that shadows `eval` as a parameter → blocks
+//    indirect-eval escape `(0, eval)("this")`
+// 4. Temporarily neuter Function.prototype.constructor (and async/generator
+//    variants) → blocks `(() => {}).constructor("return globalThis")()`
+// 5. User code runs in strict mode inside the inner IIFE.
+// ---------------------------------------------------------------------------
+const FunctionProto = Object.getPrototypeOf(function () {});
+const origAsyncProto = Object.getPrototypeOf(async function () {});
+const origGenProto = Object.getPrototypeOf(function* () {});
+const origAsyncGenProto = Object.getPrototypeOf(async function* () {});
+
+function runSandboxed(code: string, globals: Record<string, unknown>): void {
+  // Static validation — reject async constructs before execution
+  const validationError = validateScript(code);
+  if (validationError) throw new Error(validationError);
+
+  // Merge allowed globals + blocked names (blocked ones get undefined value)
+  const allNames = [...BLOCKED_GLOBALS];
+  const allValues: unknown[] = BLOCKED_GLOBALS.map(() => undefined);
+
+  for (const [name, value] of Object.entries(globals)) {
+    const idx = allNames.indexOf(name);
+    if (idx >= 0) {
+      allValues[idx] = value;
+    } else {
+      allNames.push(name);
+      allValues.push(value);
+    }
+  }
+
+  // Wrap user code:
+  //   - Outer sloppy IIFE shadows `eval` (cannot be a param name in strict mode)
+  //   - Inner strict IIFE runs the actual user code
+  // The __$nil parameter receives `undefined` and is forwarded to shadow `eval`.
+  allNames.push('__$nil');
+  allValues.push(undefined);
+  const wrapped =
+    '(function(eval){' +
+      '(function(){"use strict";\n' + code + '\n})();' +
+    '})(__$nil);';
+
+  const fn = new Function(...allNames, wrapped);
+
+  // Block constructor-chain escape: temporarily replace .constructor on
+  // Function / AsyncFunction / GeneratorFunction / AsyncGeneratorFunction
+  // prototypes with a throwing stub.
+  const origCtor = FunctionProto.constructor;
+  const origAsyncCtor = origAsyncProto.constructor;
+  const origGenCtor = origGenProto.constructor;
+  const origAsyncGenCtor = origAsyncGenProto.constructor;
+  const throwing = function () { throw new Error('Function constructor is not allowed in scripts'); };
+  const neuter = (proto: object) =>
+    Object.defineProperty(proto, 'constructor', { value: throwing, configurable: true, writable: false });
+  const restore = (proto: object, orig: unknown) =>
+    Object.defineProperty(proto, 'constructor', { value: orig, configurable: true, writable: true });
+
+  neuter(FunctionProto);
+  neuter(origAsyncProto);
+  neuter(origGenProto);
+  neuter(origAsyncGenProto);
+
+  try {
+    fn(...allValues);
+  } finally {
+    restore(FunctionProto, origCtor);
+    restore(origAsyncProto, origAsyncCtor);
+    restore(origGenProto, origGenCtor);
+    restore(origAsyncGenProto, origAsyncGenCtor);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Execute pre-request script
+// ---------------------------------------------------------------------------
+export function runPreRequestScript(
+  script: string,
+  request: RequestConfig,
+  resolvedHeaders: Record<string, string>,
+  resolvedBody: string | null,
+  variables: Record<string, string>,
+  chainVars: Record<string, string>,
+): PreRequestResult {
+  const { console: fakeConsole, logs } = createConsoleCapture();
+
+  const ctx: PreRequestContext = {
+    request: {
+      method: request.method,
+      url: request.url,
+      headers: { ...resolvedHeaders },
+      body: resolvedBody,
+    },
+    variables: { ...variables },
+    chain: { ...chainVars },
+  };
+
+  try {
+    runSandboxed(script, {
+      curlit: ctx,
+      console: fakeConsole,
+      expect: createExpect,
+    });
+    return { request: ctx.request, variables: ctx.variables, chain: ctx.chain, logs };
+  } catch (err) {
+    return {
+      request: ctx.request,
+      variables: ctx.variables,
+      chain: ctx.chain,
+      logs,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Execute post-response (test) script
+// ---------------------------------------------------------------------------
+export function runTestScript(
+  script: string,
+  request: RequestConfig,
+  response: ResponseData,
+  chainVars: Record<string, string>,
+): TestScriptResult {
+  const { console: fakeConsole, logs } = createConsoleCapture();
+  const tests: TestResult[] = [];
+  const chain = { ...chainVars };
+
+  // Parse response body as JSON if possible
+  let jsonBody: unknown = undefined;
+  try {
+    jsonBody = JSON.parse(response.body);
+  } catch {
+    // not JSON
+  }
+
+  const testFn = (name: string, fn: () => void) => {
+    try {
+      fn();
+      tests.push({ name, passed: true });
+    } catch (err) {
+      tests.push({ name, passed: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  };
+
+  const responseObj = {
+    status: response.status,
+    statusText: response.statusText,
+    headers: { ...response.headers },
+    body: response.body,
+    json: jsonBody,
+    time: response.time,
+    size: response.size,
+    cookies: response.cookies,
+  };
+
+  try {
+    runSandboxed(script, {
+      curlit: {
+        response: responseObj,
+        request: {
+          method: request.method,
+          url: request.url,
+        },
+        chain,
+        test: testFn,
+      },
+      response: responseObj,
+      test: testFn,
+      expect: createExpect,
+      console: fakeConsole,
+    });
+    return { tests, chain, logs };
+  } catch (err) {
+    return {
+      tests,
+      chain,
+      logs,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- **Pre-request scripts**: JavaScript editor (Scripts tab → Pre-request) that runs before each request. Modify method, URL, headers, and body via `curlit.request` API. Includes snippet buttons for common patterns.
- **Post-response tests**: `test(name, fn)` + `expect()` assertion API with full `.not` variants. Results displayed in new Tests tab with pass/fail badges and error messages.
- **Request chaining**: `curlit.chain` persists values across requests (stored in localStorage), accessible via `{{chain.varName}}` syntax in any request field. Chain variable panel with clear-all support.

### Script sandbox (5 defense layers)
1. Parameter-shadow 30+ browser globals (window, fetch, document, localStorage, Promise, etc.)
2. Sloppy-mode IIFE shadows `eval` — blocks indirect eval escape `(0, eval)("this")`
3. Temporary `Function.prototype.constructor` neuter — blocks `(() => {}).constructor("return globalThis")()`
4. Static validation rejects `async`/`await`/`import()` keywords (with string/comment stripping to avoid false positives)
5. Scripts stripped from imported collections to prevent untrusted code execution

### UI additions
- **Scripts tab** in RequestPanel with Pre-request/Tests sub-tabs, CodeMirror JS editors, snippet buttons
- **Tests tab** in ResponsePanel showing pass/fail summary and individual results
- **Console tab** in ResponsePanel showing `console.log/warn/error` output from scripts
- **Chain Variables** panel showing stored values with `{{chain.key}}` syntax

## Test plan
- [x] All 344 existing tests pass with no regressions
- [x] TypeScript compiles clean
- [x] Pre-request script modifies headers, body, URL — verified in browser
- [x] Post-response tests with expect().toBe/.toContain/.not.toMatch — all pass
- [x] Chain variables saved from response, accessible in next request via `{{chain.varName}}`
- [x] Sandbox blocks: `window`/`fetch`/`document` (undefined), indirect eval, constructor chain, async/await, import()
- [x] False positives: `'await'` in strings, `// async` in comments, `obj.async` property access — all allowed
- [x] Scripts stripped on collection import (Postman + native format)
- [x] Query-style API key auth preserved when pre-request script runs
- [x] Response panel tab switching doesn't go blank (key-based remount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)