### PR TITLE
Add WebSocket support

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,7 +49,7 @@
 - [x] Pre-request scripts (JavaScript, runs before send)
 - [x] Post-response tests (assertions on status, body, headers)
 - [x] Request chaining -- use values from one response in the next request
-- [ ] WebSocket support
+- [x] WebSocket support
 
 ### v1.3 -- Collaboration & Sync
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-hot-toast": "^2.6.0",
         "react-resizable-panels": "^4.9.0",
         "uuid": "^13.0.0",
+        "ws": "^8.20.0",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -46,6 +47,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^4.7.0",
         "concurrently": "^9.2.1",
         "eslint": "^9.39.4",
@@ -2710,6 +2712,16 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -7439,6 +7451,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-hot-toast": "^2.6.0",
     "react-resizable-panels": "^4.9.0",
     "uuid": "^13.0.0",
+    "ws": "^8.20.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
@@ -54,6 +55,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.7.0",
     "concurrently": "^9.2.1",
     "eslint": "^9.39.4",

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import crypto from 'crypto';
 import { Agent } from 'undici';
+import { WebSocketServer, WebSocket as WsClient } from 'ws';
 
 const app = express();
 const PORT = 3001;
@@ -249,7 +250,103 @@ export { app };
 // Only start server when not in test environment
 const isTest = process.env.NODE_ENV === 'test' || process.env.VITEST;
 if (!isTest) {
-  app.listen(PORT, () => {
+  const server = app.listen(PORT, () => {
     console.log(`CurlIt proxy server running on http://localhost:${PORT}`);
+  });
+
+  /**
+   * WebSocket relay: browser <--WS--> proxy <--ws lib--> target server.
+   * The first message from the browser is a JSON control frame:
+   *   { type: 'connect', url, headers, sslVerification }
+   * After that:
+   *   { type: 'message', data }   — relay to target
+   *   { type: 'close' }           — close target connection
+   *
+   * Proxy sends back to browser:
+   *   { type: 'connected' }
+   *   { type: 'message', data }
+   *   { type: 'error', message }
+   *   { type: 'closed', code, reason }
+   */
+  const wss = new WebSocketServer({ server, path: '/api/ws-proxy' });
+
+  wss.on('connection', (clientWs) => {
+    let targetWs = null;
+    let connected = false;
+
+    clientWs.on('message', (raw) => {
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        clientWs.send(JSON.stringify({ type: 'error', message: 'Invalid JSON' }));
+        return;
+      }
+
+      if (msg.type === 'connect' && !connected) {
+        const wsOptions = {};
+        if (msg.headers && Object.keys(msg.headers).length > 0) {
+          wsOptions.headers = msg.headers;
+        }
+        if (msg.sslVerification === false) {
+          wsOptions.rejectUnauthorized = false;
+        }
+
+        try {
+          targetWs = new WsClient(msg.url, wsOptions);
+        } catch (err) {
+          clientWs.send(JSON.stringify({ type: 'error', message: err.message }));
+          return;
+        }
+
+        targetWs.on('open', () => {
+          connected = true;
+          clientWs.send(JSON.stringify({ type: 'connected' }));
+        });
+
+        targetWs.on('message', (data, isBinary) => {
+          if (clientWs.readyState === WsClient.OPEN) {
+            if (isBinary) {
+              const base64 = Buffer.from(data).toString('base64');
+              clientWs.send(JSON.stringify({ type: 'message', data: base64, isBinary: true, size: data.byteLength }));
+            } else {
+              clientWs.send(JSON.stringify({ type: 'message', data: data.toString() }));
+            }
+          }
+        });
+
+        targetWs.on('close', (code, reason) => {
+          connected = false;
+          if (clientWs.readyState === WsClient.OPEN) {
+            clientWs.send(JSON.stringify({ type: 'closed', code, reason: reason.toString() }));
+            clientWs.close();
+          }
+        });
+
+        targetWs.on('error', (err) => {
+          connected = false;
+          if (clientWs.readyState === WsClient.OPEN) {
+            clientWs.send(JSON.stringify({ type: 'error', message: err.message }));
+            clientWs.close();
+          }
+        });
+      } else if (msg.type === 'message' && targetWs && connected) {
+        targetWs.send(msg.data);
+      } else if (msg.type === 'close') {
+        if (targetWs) {
+          targetWs.close();
+          targetWs = null;
+        }
+        connected = false;
+      }
+    });
+
+    clientWs.on('close', () => {
+      if (targetWs) {
+        targetWs.close();
+        targetWs = null;
+      }
+      connected = false;
+    });
   });
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { CurlExportModal } from './components/CurlExportModal';
 import { OpenApiImportModal } from './components/OpenApiImportModal';
 import { SaveRequestModal } from './components/SaveRequestModal';
 import { useResizable } from './hooks/useResizable';
+import { disconnectWebSocket } from './utils/websocket';
 
 function App() {
   const activeTabId = useAppStore(s => s.activeTabId);
@@ -105,6 +106,20 @@ function App() {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleKeyDown]);
+
+  // Close all WebSocket connections on page unload
+  useEffect(() => {
+    const cleanup = () => {
+      const state = useAppStore.getState();
+      for (const requestId of Object.keys(state.webSocketSessions)) {
+        if (state.webSocketSessions[requestId]?.status === 'connected') {
+          disconnectWebSocket(requestId);
+        }
+      }
+    };
+    window.addEventListener('beforeunload', cleanup);
+    return () => window.removeEventListener('beforeunload', cleanup);
+  }, []);
 
   return (
     <div className="flex flex-col h-full bg-dark-900">
@@ -214,6 +229,7 @@ function App() {
                   response={activeResponse ?? null}
                   loading={!!activeLoading}
                   requestId={activeRequest.id}
+                  protocol={activeRequest.protocol}
                 />
               </div>
             </>

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -12,16 +12,94 @@ import { KeyValueEditor } from './KeyValueEditor';
 import { FormDataEditor } from './FormDataEditor';
 import { BinaryBodyEditor } from './BinaryBodyEditor';
 import { GraphQLEditor } from './GraphQLEditor';
+import { WebSocketMessageComposer } from './WebSocketMessageComposer';
 import { fetchOAuth2Token, buildAuthorizationUrl, isTokenExpired } from '../utils/oauth';
 import { resolveOAuth2Variables } from '../utils/http';
 
 type RequestTabType = 'params' | 'headers' | 'body' | 'auth' | 'scripts';
+type WsRequestTabType = 'message' | 'params' | 'headers' | 'auth';
 
 interface Props {
   request: RequestConfig;
 }
 
 export function RequestPanel({ request }: Props) {
+  const isWs = request.protocol === 'websocket';
+
+  if (isWs) {
+    return <WebSocketRequestPanel request={request} />;
+  }
+
+  return <HttpRequestPanel request={request} />;
+}
+
+function WebSocketRequestPanel({ request }: { request: RequestConfig }) {
+  const [activeTab, setActiveTab] = useState<WsRequestTabType>('message');
+  const updateRequest = useAppStore(s => s.updateRequest);
+
+  const tabs: { id: WsRequestTabType; label: string; count?: number }[] = [
+    { id: 'message', label: 'Message' },
+    { id: 'params', label: 'Params', count: request.params.filter(p => p.enabled && p.key).length },
+    { id: 'headers', label: 'Headers', count: request.headers.filter(h => h.enabled && h.key).length },
+    { id: 'auth', label: 'Auth' },
+  ];
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center border-b border-dark-600 bg-dark-800/50">
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer ${
+              activeTab === tab.id
+                ? 'text-dark-100 border-b-2 border-accent-blue'
+                : 'text-dark-300 hover:text-dark-200'
+            }`}
+          >
+            {tab.label}
+            {tab.count !== undefined && tab.count > 0 && (
+              <span className="ml-1.5 px-1.5 py-0.5 text-[10px] bg-accent-blue/20 text-accent-blue rounded-full">
+                {tab.count}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-auto p-2">
+        {activeTab === 'message' && (
+          <WebSocketMessageComposer requestId={request.id} />
+        )}
+
+        {activeTab === 'params' && (
+          <KeyValueEditor
+            pairs={request.params}
+            onChange={params => updateRequest(request.id, { params })}
+            keyPlaceholder="Parameter"
+            valuePlaceholder="Value"
+            showDescription
+          />
+        )}
+
+        {activeTab === 'headers' && (
+          <KeyValueEditor
+            pairs={request.headers}
+            onChange={headers => updateRequest(request.id, { headers })}
+            keyPlaceholder="Header"
+            valuePlaceholder="Value"
+          />
+        )}
+
+        {activeTab === 'auth' && (
+          <AuthEditor request={request} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function HttpRequestPanel({ request }: { request: RequestConfig }) {
   const [activeTab, setActiveTab] = useState<RequestTabType>('params');
   const updateRequest = useAppStore(s => s.updateRequest);
 

--- a/src/components/RequestTabs.tsx
+++ b/src/components/RequestTabs.tsx
@@ -47,7 +47,7 @@ export function RequestTabs() {
               : 'bg-dark-900 text-dark-300 hover:bg-dark-800/50'
           }`}
         >
-          <MethodBadge method={tab.method} size="sm" />
+          <MethodBadge method={tab.protocol === 'websocket' ? 'WS' : tab.method} size="sm" />
           {editingTabId === tab.id ? (
             <input
               ref={inputRef}

--- a/src/components/ResponsePanel.tsx
+++ b/src/components/ResponsePanel.tsx
@@ -6,19 +6,24 @@ import { html } from '@codemirror/lang-html';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { search, openSearchPanel } from '@codemirror/search';
 import { Copy, Check, FileDown, Search, CircleCheck, CircleX, Terminal } from 'lucide-react';
-import type { ResponseData } from '../types';
+import type { ResponseData, RequestProtocol } from '../types';
 import { getStatusColor, formatBytes, formatTime, tryFormatJson } from '../utils/http';
 import { useAppStore } from '../store';
+import { WebSocketMessageLog } from './WebSocketMessageLog';
 
 interface Props {
   response: ResponseData | null;
   loading: boolean;
   requestId: string;
+  protocol?: RequestProtocol;
 }
 
 type ResponseTab = 'body' | 'headers' | 'cookies' | 'tests' | 'console';
 
-export function ResponsePanel({ response, loading, requestId }: Props) {
+export function ResponsePanel({ response, loading, requestId, protocol }: Props) {
+  if (protocol === 'websocket') {
+    return <WebSocketMessageLog requestId={requestId} />;
+  }
   const [activeTab, setActiveTab] = useState<ResponseTab>('body');
   const [copied, setCopied] = useState(false);
   const [bodyFormat, setBodyFormat] = useState<'pretty' | 'raw'>('pretty');

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -291,7 +291,7 @@ function CollectionItem({ collection }: { collection: Collection }) {
                 onClick={() => openRequestFromCollection(collection.id, req.id)}
                 className="flex-1 flex items-center gap-2 px-3 py-1.5 hover:bg-dark-800/50 transition-colors cursor-pointer"
               >
-                <MethodBadge method={req.method} size="sm" />
+                <MethodBadge method={req.protocol === 'websocket' ? 'WS' : req.method} size="sm" />
                 <span className="text-xs text-dark-300 truncate">{req.name || req.url || 'Untitled'}</span>
               </button>
               <button
@@ -380,7 +380,7 @@ function HistoryPanel() {
                 onClick={() => openFromHistory(entry)}
                 className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-dark-800/50 transition-colors cursor-pointer"
               >
-                <MethodBadge method={entry.request.method} size="sm" />
+                <MethodBadge method={entry.request.protocol === 'websocket' ? 'WS' : entry.request.method} size="sm" />
                 <span className="text-xs text-dark-300 truncate flex-1 text-left">
                   {entry.request.url || 'Untitled'}
                 </span>

--- a/src/components/UrlBar.tsx
+++ b/src/components/UrlBar.tsx
@@ -1,9 +1,10 @@
-import { Send, Loader2, ShieldCheck, ShieldOff } from 'lucide-react';
+import { Send, Loader2, ShieldCheck, ShieldOff, Plug, Unplug } from 'lucide-react';
 import type { HttpMethod, RequestConfig } from '../types';
 import { useAppStore } from '../store';
 import { sendRequest, resolveRequestVariables, buildHeaders, buildBody } from '../utils/http';
 import { getMethodColor } from '../utils/http';
 import { runPreRequestScript, runTestScript } from '../utils/scriptEngine';
+import { isWebSocketUrl, connectWebSocket, disconnectWebSocket } from '../utils/websocket';
 
 const METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
 
@@ -22,6 +23,35 @@ export function UrlBar({ request }: Props) {
   const setTestResults = useAppStore(s => s.setTestResults);
   const setScriptLogs = useAppStore(s => s.setScriptLogs);
   const loading = useAppStore(s => s.loadingRequests[request.id]);
+  const wsSession = useAppStore(s => s.webSocketSessions[request.id]);
+
+  const isWs = request.protocol === 'websocket';
+  const wsStatus = wsSession?.status ?? 'disconnected';
+
+  const handleUrlChange = (url: string) => {
+    const updates: Partial<RequestConfig> = { url };
+    if (isWebSocketUrl(url) && request.protocol !== 'websocket') {
+      updates.protocol = 'websocket';
+    } else if (!isWebSocketUrl(url) && request.protocol === 'websocket') {
+      // Switching away from WS -- tear down any active connection
+      disconnectWebSocket(request.id);
+      useAppStore.getState().setWebSocketStatus(request.id, 'disconnected');
+      updates.protocol = 'http';
+    }
+    updateRequest(request.id, updates);
+  };
+
+  const handleConnect = () => {
+    if (!request.url.trim()) return;
+    const variables = getActiveVariables();
+    const chainVars = getChainVariables();
+    connectWebSocket(request, variables, chainVars);
+  };
+
+  const handleDisconnect = () => {
+    disconnectWebSocket(request.id);
+    useAppStore.getState().setWebSocketStatus(request.id, 'disconnected');
+  };
 
   const handleSend = async () => {
     if (!request.url.trim() || loading) return;
@@ -173,34 +203,65 @@ export function UrlBar({ request }: Props) {
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      handleSend();
+      if (isWs) {
+        if (wsStatus === 'disconnected' || wsStatus === 'error') handleConnect();
+      } else {
+        handleSend();
+      }
     }
   };
 
   return (
     <div className="flex items-center gap-2 p-3 bg-dark-800 border-b border-dark-600">
-      {/* Method Selector */}
-      <select
-        value={request.method}
-        onChange={e => updateRequest(request.id, { method: e.target.value as HttpMethod })}
-        className={`bg-dark-700 border border-dark-500 rounded-lg px-3 py-2.5 text-sm font-bold cursor-pointer ${getMethodColor(request.method)}`}
-      >
-        {METHODS.map(m => (
-          <option key={m} value={m}>
-            {m}
-          </option>
-        ))}
-      </select>
+      {/* Method Selector / WS badge */}
+      {isWs ? (
+        <span className={`${getMethodColor('WS')} bg-dark-700 border border-dark-500 rounded-lg px-3 py-2.5 text-sm font-bold`}>
+          WS
+        </span>
+      ) : (
+        <select
+          value={request.method}
+          onChange={e => updateRequest(request.id, { method: e.target.value as HttpMethod })}
+          className={`bg-dark-700 border border-dark-500 rounded-lg px-3 py-2.5 text-sm font-bold cursor-pointer ${getMethodColor(request.method)}`}
+        >
+          {METHODS.map(m => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+      )}
 
       {/* URL Input */}
-      <input
-        type="text"
-        value={request.url}
-        onChange={e => updateRequest(request.id, { url: e.target.value })}
-        onKeyDown={handleKeyDown}
-        placeholder="Enter URL or paste cURL command..."
-        className="flex-1 bg-dark-700 border border-dark-500 rounded-lg px-4 py-2.5 text-sm text-dark-100 placeholder:text-dark-400 font-mono"
-      />
+      <div className="flex-1 relative flex items-center">
+        <input
+          type="text"
+          value={request.url}
+          onChange={e => handleUrlChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={isWs ? 'Enter WebSocket URL (ws:// or wss://)...' : 'Enter URL or paste cURL command...'}
+          className="w-full bg-dark-700 border border-dark-500 rounded-lg px-4 py-2.5 text-sm text-dark-100 placeholder:text-dark-400 font-mono"
+        />
+        {/* Connection status indicator for WS */}
+        {isWs && wsStatus !== 'disconnected' && (
+          <span className="absolute right-3 flex items-center gap-1.5">
+            <span className={`w-2 h-2 rounded-full ${
+              wsStatus === 'connected' ? 'bg-accent-green' :
+              wsStatus === 'connecting' ? 'bg-accent-yellow animate-pulse' :
+              'bg-accent-red'
+            }`} />
+            <span className={`text-[10px] font-medium ${
+              wsStatus === 'connected' ? 'text-accent-green' :
+              wsStatus === 'connecting' ? 'text-accent-yellow' :
+              'text-accent-red'
+            }`}>
+              {wsStatus === 'connected' ? 'Connected' :
+               wsStatus === 'connecting' ? 'Connecting...' :
+               'Error'}
+            </span>
+          </span>
+        )}
+      </div>
 
       {/* SSL Verification Toggle */}
       <button
@@ -215,19 +276,44 @@ export function UrlBar({ request }: Props) {
         {request.sslVerification === false ? <ShieldOff size={16} /> : <ShieldCheck size={16} />}
       </button>
 
-      {/* Send Button */}
-      <button
-        onClick={handleSend}
-        disabled={loading || !request.url.trim()}
-        className="flex items-center gap-2 bg-accent-blue hover:bg-accent-blue/80 disabled:opacity-50 disabled:cursor-not-allowed text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-colors cursor-pointer"
-      >
-        {loading ? (
-          <Loader2 size={16} className="animate-spin" />
+      {/* Send / Connect / Disconnect Button */}
+      {isWs ? (
+        wsStatus === 'connected' ? (
+          <button
+            onClick={handleDisconnect}
+            className="flex items-center gap-2 bg-accent-red hover:bg-accent-red/80 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-colors cursor-pointer"
+          >
+            <Unplug size={16} />
+            Disconnect
+          </button>
         ) : (
-          <Send size={16} />
-        )}
-        Send
-      </button>
+          <button
+            onClick={handleConnect}
+            disabled={wsStatus === 'connecting' || !request.url.trim()}
+            className="flex items-center gap-2 bg-accent-green hover:bg-accent-green/80 disabled:opacity-50 disabled:cursor-not-allowed text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-colors cursor-pointer"
+          >
+            {wsStatus === 'connecting' ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Plug size={16} />
+            )}
+            {wsStatus === 'connecting' ? 'Connecting...' : 'Connect'}
+          </button>
+        )
+      ) : (
+        <button
+          onClick={handleSend}
+          disabled={loading || !request.url.trim()}
+          className="flex items-center gap-2 bg-accent-blue hover:bg-accent-blue/80 disabled:opacity-50 disabled:cursor-not-allowed text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-colors cursor-pointer"
+        >
+          {loading ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            <Send size={16} />
+          )}
+          Send
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/WebSocketMessageComposer.tsx
+++ b/src/components/WebSocketMessageComposer.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import CodeMirror from '@uiw/react-codemirror';
+import { json } from '@codemirror/lang-json';
+import { oneDark } from '@codemirror/theme-one-dark';
+import { Send } from 'lucide-react';
+import { useAppStore } from '../store';
+import type { Theme } from '../store';
+import { sendWebSocketMessage } from '../utils/websocket';
+
+type MessageFormat = 'text' | 'json';
+
+interface Props {
+  requestId: string;
+}
+
+export function WebSocketMessageComposer({ requestId }: Props) {
+  const [message, setMessage] = useState('');
+  const [format, setFormat] = useState<MessageFormat>('text');
+  const theme = useAppStore(s => s.theme) as Theme;
+  const wsSession = useAppStore(s => s.webSocketSessions[requestId]);
+  const isConnected = wsSession?.status === 'connected';
+
+  const handleSend = () => {
+    const trimmed = message.trim();
+    if (!trimmed || !isConnected) return;
+    sendWebSocketMessage(requestId, trimmed);
+    setMessage('');
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Format selector */}
+      <div className="flex items-center gap-1">
+        {(['text', 'json'] as const).map(f => (
+          <button
+            key={f}
+            onClick={() => setFormat(f)}
+            className={`px-3 py-1.5 text-xs rounded-md font-medium transition-colors cursor-pointer ${
+              format === f
+                ? 'bg-accent-blue text-white'
+                : 'bg-dark-700 text-dark-300 hover:text-dark-100'
+            }`}
+          >
+            {f === 'text' ? 'Text' : 'JSON'}
+          </button>
+        ))}
+      </div>
+
+      {/* Message editor */}
+      <div
+        className="border border-dark-600 rounded-lg overflow-hidden h-[200px]"
+        onKeyDown={(e) => {
+          if (e.ctrlKey && e.key === 'Enter') {
+            e.preventDefault();
+            handleSend();
+          }
+        }}
+      >
+        <CodeMirror
+          value={message}
+          onChange={setMessage}
+          extensions={format === 'json' ? [json()] : []}
+          theme={theme === 'dark' ? oneDark : 'light'}
+          height="200px"
+          placeholder={format === 'json' ? '{\n  "type": "hello",\n  "data": "world"\n}' : 'Type a message to send...'}
+          basicSetup={{
+            lineNumbers: true,
+            foldGutter: true,
+            bracketMatching: true,
+            closeBrackets: true,
+          }}
+        />
+      </div>
+
+      {/* Send button */}
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-dark-400">Ctrl+Enter to send</span>
+        <button
+          onClick={handleSend}
+          disabled={!isConnected || !message.trim()}
+          className="flex items-center gap-2 bg-accent-blue hover:bg-accent-blue/80 disabled:opacity-40 disabled:cursor-not-allowed text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer"
+        >
+          <Send size={14} />
+          Send Message
+        </button>
+      </div>
+
+      {!isConnected && (
+        <div className="text-dark-400 text-xs text-center py-2">
+          Connect to a WebSocket server to send messages
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/WebSocketMessageLog.tsx
+++ b/src/components/WebSocketMessageLog.tsx
@@ -1,0 +1,227 @@
+import { useState, useEffect, useRef } from 'react';
+import { ArrowUp, ArrowDown, Trash2, Search, Clock } from 'lucide-react';
+import { useAppStore } from '../store';
+import { formatBytes } from '../utils/http';
+import type { WebSocketMessage } from '../types';
+
+interface Props {
+  requestId: string;
+}
+
+type FilterMode = 'all' | 'sent' | 'received';
+
+export function WebSocketMessageLog({ requestId }: Props) {
+  const wsSession = useAppStore(s => s.webSocketSessions[requestId]);
+  const clearMessages = useAppStore(s => s.clearWebSocketMessages);
+  const [filter, setFilter] = useState<FilterMode>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const messages = wsSession?.messages ?? [];
+  const status = wsSession?.status ?? 'disconnected';
+  const connectedAt = wsSession?.connectedAt;
+  const error = wsSession?.error;
+
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.length]);
+
+  const filteredMessages = messages.filter(msg => {
+    if (filter !== 'all' && msg.direction !== filter) return false;
+    if (searchQuery && !msg.data.toLowerCase().includes(searchQuery.toLowerCase())) return false;
+    return true;
+  });
+
+  const sentCount = messages.filter(m => m.direction === 'sent').length;
+  const receivedCount = messages.filter(m => m.direction === 'received').length;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Status bar */}
+      <div className="flex items-center justify-between px-3 py-2 bg-dark-800/50 border-b border-dark-600">
+        <div className="flex items-center gap-3">
+          {/* Filter buttons */}
+          {(['all', 'sent', 'received'] as const).map(mode => (
+            <button
+              key={mode}
+              onClick={() => setFilter(mode)}
+              className={`text-xs font-medium transition-colors cursor-pointer ${
+                filter === mode
+                  ? 'text-dark-100 border-b-2 border-accent-blue pb-0.5'
+                  : 'text-dark-300 hover:text-dark-200'
+              }`}
+            >
+              {mode === 'all' ? `All (${messages.length})` :
+               mode === 'sent' ? `Sent (${sentCount})` :
+               `Received (${receivedCount})`}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2 text-xs">
+          {/* Connection info */}
+          <span className={`flex items-center gap-1.5 font-medium ${
+            status === 'connected' ? 'text-accent-green' :
+            status === 'error' ? 'text-accent-red' :
+            'text-dark-400'
+          }`}>
+            <span className={`w-1.5 h-1.5 rounded-full ${
+              status === 'connected' ? 'bg-accent-green' :
+              status === 'error' ? 'bg-accent-red' :
+              'bg-dark-400'
+            }`} />
+            {status === 'connected' ? 'Connected' :
+             status === 'connecting' ? 'Connecting...' :
+             status === 'error' ? 'Error' :
+             'Disconnected'}
+          </span>
+          {connectedAt && status === 'connected' && (
+            <ConnectionTimer connectedAt={connectedAt} />
+          )}
+        </div>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-dark-700">
+        <div className="flex-1 relative">
+          <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-dark-400" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            placeholder="Filter messages..."
+            className="w-full bg-dark-700 border border-dark-600 rounded px-2 py-1 pl-7 text-xs text-dark-100 placeholder:text-dark-400"
+          />
+        </div>
+        <button
+          onClick={() => clearMessages(requestId)}
+          disabled={messages.length === 0}
+          className="p-1.5 text-dark-400 hover:text-accent-red disabled:opacity-30 disabled:cursor-not-allowed rounded transition-colors cursor-pointer"
+          title="Clear messages"
+        >
+          <Trash2 size={13} />
+        </button>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="px-3 py-2 bg-accent-red/10 border-b border-accent-red/30">
+          <p className="text-xs text-accent-red">{error}</p>
+        </div>
+      )}
+
+      {/* Messages list */}
+      <div className="flex-1 overflow-auto">
+        {filteredMessages.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-dark-400">
+            <div className="flex flex-col items-center gap-2 text-center">
+              <div className="text-3xl opacity-30">{ status === 'disconnected' ? '~' : '...' }</div>
+              <p className="text-xs">
+                {status === 'disconnected'
+                  ? 'Connect to a WebSocket server to see messages here'
+                  : messages.length === 0
+                    ? 'Waiting for messages...'
+                    : 'No messages match filter'}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col">
+            {filteredMessages.map(msg => (
+              <MessageRow key={msg.id} message={msg} />
+            ))}
+            <div ref={messagesEndRef} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MessageRow({ message }: { message: WebSocketMessage }) {
+  const [expanded, setExpanded] = useState(false);
+  const isSent = message.direction === 'sent';
+  const isJson = (() => { try { JSON.parse(message.data); return true; } catch { return false; } })();
+  const displayData = expanded && isJson
+    ? JSON.stringify(JSON.parse(message.data), null, 2)
+    : message.data;
+  const isLong = message.data.length > 200;
+
+  return (
+    <div
+      className={`flex gap-2 px-3 py-2 border-b border-dark-700/50 hover:bg-dark-800/30 ${
+        isSent ? 'bg-accent-blue/3' : 'bg-accent-green/3'
+      }`}
+    >
+      {/* Direction icon */}
+      <div className="flex-shrink-0 mt-0.5">
+        {isSent ? (
+          <ArrowUp size={13} className="text-accent-orange" />
+        ) : (
+          <ArrowDown size={13} className="text-accent-green" />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        {message.isBinary && (
+          <span className="inline-block px-1.5 py-0.5 text-[9px] bg-accent-purple/15 text-accent-purple rounded font-medium mb-1">
+            BINARY
+          </span>
+        )}
+        <pre
+          className={`text-xs font-mono text-dark-200 whitespace-pre-wrap break-all ${
+            !expanded && isLong ? 'line-clamp-3' : ''
+          }`}
+          onClick={() => isLong || isJson ? setExpanded(!expanded) : undefined}
+          style={isLong || isJson ? { cursor: 'pointer' } : undefined}
+        >
+          {displayData}
+        </pre>
+        {(isLong || isJson) && !expanded && (
+          <button
+            onClick={() => setExpanded(true)}
+            className="text-[10px] text-accent-blue hover:underline mt-0.5 cursor-pointer"
+          >
+            {isJson ? 'Expand JSON' : 'Show more'}
+          </button>
+        )}
+      </div>
+
+      {/* Meta */}
+      <div className="flex flex-col items-end gap-0.5 flex-shrink-0 text-[10px] text-dark-400">
+        <span>{formatTimestamp(message.timestamp)}</span>
+        <span>{formatBytes(message.size)}</span>
+      </div>
+    </div>
+  );
+}
+
+function ConnectionTimer({ connectedAt }: { connectedAt: number }) {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => setTick(t => t + 1), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const elapsed = Math.floor((Date.now() - connectedAt) / 1000);
+  const mins = Math.floor(elapsed / 60);
+  const secs = elapsed % 60;
+  const display = mins > 0
+    ? `${mins}m ${secs.toString().padStart(2, '0')}s`
+    : `${secs}s`;
+
+  return (
+    <span className="flex items-center gap-1 text-dark-400">
+      <Clock size={10} />
+      {display}
+    </span>
+  );
+}
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}:${d.getSeconds().toString().padStart(2, '0')}.${d.getMilliseconds().toString().padStart(3, '0')}`;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,7 @@
   --color-method-delete: #e74c3c;
   --color-method-head: #2ecc71;
   --color-method-options: #95a5a6;
+  --color-method-ws: #9b59b6;
 }
 
 :root {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,8 +9,11 @@ import type {
   HttpMethod,
   TestResult,
   ScriptConsoleEntry,
+  WebSocketSession,
+  WebSocketMessage,
+  WebSocketConnectionStatus,
 } from '../types';
-import { createDefaultRequest } from '../types';
+import { createDefaultRequest, createDefaultWebSocketSession } from '../types';
 import { removeFilesForRequest } from '../utils/fileStore';
 
 const STORAGE_KEYS = {
@@ -67,6 +70,9 @@ interface AppState {
   scriptLogs: Record<string, ScriptConsoleEntry[]>;
   chainVariables: Record<string, string>;
 
+  // WebSocket
+  webSocketSessions: Record<string, WebSocketSession>;
+
   // UI
   theme: Theme;
   sidebarView: SidebarView;
@@ -110,6 +116,12 @@ interface AppState {
   clearChainVariables: () => void;
   getChainVariables: () => Record<string, string>;
 
+  // Actions - WebSocket
+  setWebSocketStatus: (requestId: string, status: WebSocketConnectionStatus, error?: string | null) => void;
+  addWebSocketMessage: (requestId: string, message: WebSocketMessage) => void;
+  clearWebSocketMessages: (requestId: string) => void;
+  resetWebSocketSession: (requestId: string) => void;
+
   // Actions - Save
   saveActiveRequest: () => 'saved' | 'needs-collection';
   markTabSaved: (tabId: string, collectionId: string, sourceRequestId: string) => void;
@@ -145,6 +157,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   testResults: {},
   scriptLogs: {},
   chainVariables: loadFromStorage<Record<string, string>>(STORAGE_KEYS.chainVariables, {}),
+  webSocketSessions: {},
   theme: loadFromStorage<Theme>(STORAGE_KEYS.theme, 'dark'),
   sidebarView: 'collections',
   sidebarOpen: true,
@@ -160,6 +173,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       requestId: request.id,
       name: request.name,
       method: request.method,
+      protocol: request.protocol,
       isModified: false,
     };
     set(state => ({
@@ -187,6 +201,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       requestId: newReq.id,
       name: newReq.name,
       method: newReq.method,
+      protocol: newReq.protocol,
       isModified: false,
     };
     set(s => ({
@@ -201,11 +216,15 @@ export const useAppStore = create<AppState>((set, get) => ({
       const newTabs = state.tabs.filter(t => t.id !== tabId);
       const newRequests = { ...state.requests };
       const newResponses = { ...state.responses };
+      const newWsSessions = { ...state.webSocketSessions };
       const tab = state.tabs.find(t => t.id === tabId);
       if (tab) {
+        // Lazy import to avoid circular dependency (websocket.ts imports this store)
+        import('../utils/websocket').then(m => m.disconnectWebSocket(tab.requestId));
         removeFilesForRequest(tab.requestId);
         delete newRequests[tab.requestId];
         delete newResponses[tab.requestId];
+        delete newWsSessions[tab.requestId];
       }
 
       let newActiveTabId = state.activeTabId;
@@ -234,6 +253,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         activeTabId: newActiveTabId,
         requests: newRequests,
         responses: newResponses,
+        webSocketSessions: newWsSessions,
       };
     });
   },
@@ -248,7 +268,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       const updated = { ...existing, ...updates };
       const newTabs = state.tabs.map(t =>
         t.requestId === id
-          ? { ...t, name: updated.name, method: updated.method as HttpMethod, isModified: true }
+          ? { ...t, name: updated.name, method: updated.method as HttpMethod, protocol: updated.protocol, isModified: true }
           : t
       );
       return {
@@ -355,6 +375,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         requestId: newReq.id,
         name: newReq.name,
         method: newReq.method,
+        protocol: newReq.protocol,
         isModified: false,
         collectionId,
         sourceRequestId: requestId,
@@ -473,6 +494,59 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   getChainVariables: () => get().chainVariables,
+
+  // WebSocket actions
+  setWebSocketStatus: (requestId, status, error) => {
+    set(state => {
+      // Guard: don't create entries for requests that have been removed (e.g. late callbacks after tab close)
+      if (!state.requests[requestId]) return state;
+      const session = state.webSocketSessions[requestId] || createDefaultWebSocketSession();
+      const updated = { ...session, status, error: error ?? null };
+      if (status === 'connected') {
+        updated.connectedAt = Date.now();
+        updated.disconnectedAt = null;
+      } else if (status === 'disconnected') {
+        updated.disconnectedAt = Date.now();
+      }
+      return { webSocketSessions: { ...state.webSocketSessions, [requestId]: updated } };
+    });
+  },
+
+  addWebSocketMessage: (requestId, message) => {
+    set(state => {
+      if (!state.requests[requestId]) return state;
+      const session = state.webSocketSessions[requestId] || createDefaultWebSocketSession();
+      const messages = [...session.messages, message].slice(-1000);
+      return {
+        webSocketSessions: {
+          ...state.webSocketSessions,
+          [requestId]: { ...session, messages },
+        },
+      };
+    });
+  },
+
+  clearWebSocketMessages: (requestId) => {
+    set(state => {
+      const session = state.webSocketSessions[requestId];
+      if (!session) return state;
+      return {
+        webSocketSessions: {
+          ...state.webSocketSessions,
+          [requestId]: { ...session, messages: [] },
+        },
+      };
+    });
+  },
+
+  resetWebSocketSession: (requestId) => {
+    set(state => ({
+      webSocketSessions: {
+        ...state.webSocketSessions,
+        [requestId]: createDefaultWebSocketSession(),
+      },
+    }));
+  },
 
   // Save actions
   saveActiveRequest: () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,28 @@
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
 
+export type RequestProtocol = 'http' | 'websocket';
+
+export type WebSocketConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+export type WebSocketMessageDirection = 'sent' | 'received';
+
+export interface WebSocketMessage {
+  id: string;
+  direction: WebSocketMessageDirection;
+  data: string;
+  timestamp: number;
+  size: number;
+  isBinary?: boolean;
+}
+
+export interface WebSocketSession {
+  status: WebSocketConnectionStatus;
+  messages: WebSocketMessage[];
+  connectedAt: number | null;
+  disconnectedAt: number | null;
+  error: string | null;
+}
+
 export interface KeyValuePair {
   id: string;
   key: string;
@@ -58,6 +81,7 @@ export interface RequestConfig {
   name: string;
   method: HttpMethod;
   url: string;
+  protocol?: RequestProtocol;
   params: KeyValuePair[];
   headers: KeyValuePair[];
   body: {
@@ -133,6 +157,7 @@ export interface Tab {
   requestId: string;
   name: string;
   method: HttpMethod;
+  protocol?: RequestProtocol;
   isModified: boolean;
   collectionId?: string;
   sourceRequestId?: string;
@@ -154,6 +179,16 @@ export function createDefaultRequest(overrides?: Partial<RequestConfig>): Reques
     },
     auth: { type: 'none' },
     ...overrides,
+  };
+}
+
+export function createDefaultWebSocketSession(): WebSocketSession {
+  return {
+    status: 'disconnected',
+    messages: [],
+    connectedAt: null,
+    disconnectedAt: null,
+    error: null,
   };
 }
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -5,7 +5,7 @@ export function buildUrl(baseUrl: string, params: KeyValuePair[]): string {
   const enabledParams = params.filter(p => p.enabled && p.key);
   if (enabledParams.length === 0) return baseUrl;
 
-  const url = new URL(baseUrl.startsWith('http') ? baseUrl : `https://${baseUrl}`);
+  const url = new URL(/^(https?|wss?):\/\//.test(baseUrl) ? baseUrl : `https://${baseUrl}`);
   enabledParams.forEach(p => url.searchParams.append(p.key, p.value));
   return url.toString();
 }
@@ -498,6 +498,7 @@ export function getMethodColor(method: string): string {
     DELETE: 'text-method-delete',
     HEAD: 'text-method-head',
     OPTIONS: 'text-method-options',
+    WS: 'text-method-ws',
   };
   return colors[method] || 'text-dark-300';
 }
@@ -511,6 +512,7 @@ export function getMethodBgColor(method: string): string {
     DELETE: 'bg-method-delete/10 border-method-delete/30',
     HEAD: 'bg-method-head/10 border-method-head/30',
     OPTIONS: 'bg-method-options/10 border-method-options/30',
+    WS: 'bg-method-ws/10 border-method-ws/30',
   };
   return colors[method] || '';
 }

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -1,0 +1,153 @@
+import { useAppStore } from '../store';
+import { buildHeaders, buildUrl, resolveRequestVariables } from './http';
+import type { RequestConfig, WebSocketMessage } from '../types';
+
+const activeConnections = new Map<string, WebSocket>();
+
+function buildProxyUrl(): string {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${protocol}//${window.location.host}/api/ws-proxy`;
+}
+
+export function isWebSocketUrl(url: string): boolean {
+  const trimmed = url.trim().toLowerCase();
+  return trimmed.startsWith('ws://') || trimmed.startsWith('wss://');
+}
+
+export function connectWebSocket(request: RequestConfig, envVars: Record<string, string>, chainVars: Record<string, string>): void {
+  const { id: requestId } = request;
+  const store = useAppStore.getState();
+
+  // Close existing connection if any
+  disconnectWebSocket(requestId);
+
+  store.setWebSocketStatus(requestId, 'connecting');
+
+  const resolved = resolveRequestVariables(request, envVars, chainVars);
+  const headers = buildHeaders(resolved.headers, resolved.auth);
+
+  // Build URL with query params (same as HTTP path)
+  let targetUrl = buildUrl(resolved.url, resolved.params);
+
+  // Append API key as query param if configured
+  if (resolved.auth.type === 'api-key' && resolved.auth.apiKey?.addTo === 'query') {
+    const urlObj = new URL(targetUrl.startsWith('ws') ? targetUrl : `wss://${targetUrl}`);
+    urlObj.searchParams.append(resolved.auth.apiKey.key, resolved.auth.apiKey.value);
+    targetUrl = urlObj.toString();
+  }
+
+  const proxyUrl = buildProxyUrl();
+  let ws: WebSocket;
+  try {
+    ws = new WebSocket(proxyUrl);
+  } catch (err) {
+    store.setWebSocketStatus(requestId, 'error', err instanceof Error ? err.message : 'Failed to create WebSocket');
+    return;
+  }
+
+  activeConnections.set(requestId, ws);
+
+  ws.onopen = () => {
+    // Send connect control frame to proxy
+    ws.send(JSON.stringify({
+      type: 'connect',
+      url: targetUrl,
+      headers,
+      sslVerification: request.sslVerification !== false,
+    }));
+  };
+
+  ws.onmessage = (event) => {
+    let msg: { type: string; data?: string; message?: string; code?: number; reason?: string; isBinary?: boolean; size?: number };
+    try {
+      msg = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+
+    const store = useAppStore.getState();
+
+    switch (msg.type) {
+      case 'connected':
+        store.setWebSocketStatus(requestId, 'connected');
+        break;
+
+      case 'message': {
+        const isBinary = msg.isBinary === true;
+        const displayData = isBinary
+          ? `[Binary frame, ${msg.size ?? 0} bytes]\n${msg.data ?? ''}`
+          : (msg.data ?? '');
+        const wsMsg: WebSocketMessage = {
+          id: crypto.randomUUID(),
+          direction: 'received',
+          data: displayData,
+          timestamp: Date.now(),
+          size: isBinary ? (msg.size ?? 0) : new Blob([msg.data ?? '']).size,
+          isBinary,
+        };
+        store.addWebSocketMessage(requestId, wsMsg);
+        break;
+      }
+
+      case 'error':
+        store.setWebSocketStatus(requestId, 'error', msg.message ?? 'Unknown error');
+        activeConnections.delete(requestId);
+        ws.close();
+        break;
+
+      case 'closed':
+        store.setWebSocketStatus(requestId, 'disconnected');
+        activeConnections.delete(requestId);
+        ws.close();
+        break;
+    }
+  };
+
+  ws.onerror = () => {
+    const store = useAppStore.getState();
+    store.setWebSocketStatus(requestId, 'error', 'Connection failed. Is the proxy server running?');
+    activeConnections.delete(requestId);
+  };
+
+  ws.onclose = () => {
+    const store = useAppStore.getState();
+    const session = store.webSocketSessions[requestId];
+    // Only set disconnected if not already in error state
+    if (session?.status !== 'error' && session?.status !== 'disconnected') {
+      store.setWebSocketStatus(requestId, 'disconnected');
+    }
+    activeConnections.delete(requestId);
+  };
+}
+
+export function sendWebSocketMessage(requestId: string, data: string): void {
+  const ws = activeConnections.get(requestId);
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+  ws.send(JSON.stringify({ type: 'message', data }));
+
+  const msg: WebSocketMessage = {
+    id: crypto.randomUUID(),
+    direction: 'sent',
+    data,
+    timestamp: Date.now(),
+    size: new Blob([data]).size,
+  };
+  useAppStore.getState().addWebSocketMessage(requestId, msg);
+}
+
+export function disconnectWebSocket(requestId: string): void {
+  const ws = activeConnections.get(requestId);
+  if (ws) {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'close' }));
+    }
+    ws.close();
+    activeConnections.delete(requestId);
+  }
+}
+
+export function isWebSocketConnected(requestId: string): boolean {
+  const ws = activeConnections.get(requestId);
+  return !!ws && ws.readyState === WebSocket.OPEN;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
+      '/api/ws-proxy': {
+        target: 'ws://localhost:3001',
+        ws: true,
+      },
       '/api': {
         target: 'http://localhost:3001',
         changeOrigin: true,


### PR DESCRIPTION
## Summary
- Full WebSocket client via proxy relay (browser <-> Express ws <-> target server), matching the existing CORS-bypass architecture
- Auto-detects `ws://` / `wss://` URLs and switches the UI to WS mode with Connect/Disconnect controls, status indicator, and connection timer
- Message composer with Text/JSON format toggle (CodeMirror editor, Ctrl+Enter to send) and live message log with sent/received filtering, search, timestamps, and byte sizes
- Supports auth headers, query params, API key, SSL toggle, and environment variable substitution on WebSocket handshake — same as HTTP requests
- Binary frame handling in the relay (base64-encoded, tagged with BINARY badge in the log)
- WS badge in tabs, sidebar collections, and history; protocol preserved through duplicate/collection/history flows

## Test plan
- [x] TypeScript compiles with zero errors
- [x] Production build succeeds (`vite build`)
- [x] All 344 existing tests pass (15/15 test files)
- [x] Verified end-to-end in browser: connect to `wss://ws.postman-echo.com/raw`, send message, receive echo
- [x] Test tab close and URL protocol switch tear down the connection
- [x] Test query params are appended correctly to WS URLs
- [ ] Test saved WS requests in collections reopen in WS mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)