### PR TITLE
Add full backup/restore as a single JSON

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,7 +53,7 @@
 
 ### v1.3 -- Collaboration & Sync
 
-- [ ] Export/import all data (full backup as single JSON)
+- [x] Export/import all data (full backup as single JSON)
 - [ ] Shareable request links (encoded in URL)
 - [ ] Optional cloud sync via GitHub Gist or a self-hosted backend
 - [ ] Team workspaces with shared collections

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -172,6 +172,29 @@ History is limited to the last 100 requests.
 
 ---
 
+## Backup & Restore
+
+Export all your CurlIt data (collections, environments, history, chain variables, and theme) as a single JSON file, and restore it later or on another machine.
+
+### Exporting a Backup
+
+1. Click **Backup** in the header
+2. Review the summary (number of collections, requests, environments, history)
+3. Click **Download Backup** -- a file named `curlit-backup-YYYY-MM-DD.json` is saved
+
+### Importing a Backup
+
+1. Click **Backup** in the header and switch to the **Import** tab
+2. Choose a backup file with **Choose File**, or paste the JSON
+3. Click **Validate** to preview the contents
+4. Pick an import mode and confirm:
+   - **Merge** (default): append to existing data; incoming collections and environments get fresh IDs so nothing is overwritten
+   - **Replace**: discard all current data and restore exactly what's in the backup
+
+Pre-request and test scripts are stripped from imported requests as a safety measure, consistent with collection imports.
+
+---
+
 ## cURL Integration
 
 ### Importing a cURL Command

--- a/e2e/backup.spec.ts
+++ b/e2e/backup.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+
+test.describe('Backup / Restore', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('export downloads a valid backup, import restores it', async ({ page }) => {
+    // ─── Seed state directly in localStorage ───────────────────────────────
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'curlit_collections',
+        JSON.stringify([
+          {
+            id: 'col-1',
+            name: 'Seeded Collection',
+            requests: [
+              {
+                id: 'req-1',
+                name: 'Seeded Request',
+                method: 'GET',
+                url: 'https://api.example.com/users',
+                params: [],
+                headers: [],
+                body: { type: 'none', raw: '', formData: [], urlencoded: [] },
+                auth: { type: 'none' },
+              },
+            ],
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ])
+      );
+      localStorage.setItem(
+        'curlit_environments',
+        JSON.stringify([
+          {
+            id: 'env-1',
+            name: 'Seeded Env',
+            variables: [{ id: 'v1', key: 'host', value: 'api.test', enabled: true }],
+            isActive: false,
+          },
+        ])
+      );
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Sanity: seeded collection is visible in sidebar
+    await expect(page.getByText('Seeded Collection')).toBeVisible();
+
+    // ─── Open Backup modal and download ────────────────────────────────────
+    await page.locator('button[title="Backup & Restore all data"]').click();
+    await expect(page.getByRole('heading', { name: 'Backup & Restore' })).toBeVisible();
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.locator('button:has-text("Download Backup")').click();
+    const download = await downloadPromise;
+
+    // File name should match the documented pattern
+    expect(download.suggestedFilename()).toMatch(/^curlit-backup-\d{4}-\d{2}-\d{2}\.json$/);
+
+    const downloadPath = await download.path();
+    const contents = fs.readFileSync(downloadPath, 'utf-8');
+    const backup = JSON.parse(contents);
+
+    // ─── Validate backup shape ─────────────────────────────────────────────
+    expect(backup.curlit_backup_version).toBe(1);
+    expect(backup.data.collections).toHaveLength(1);
+    expect(backup.data.collections[0].name).toBe('Seeded Collection');
+    expect(backup.data.collections[0].requests[0].url).toBe('https://api.example.com/users');
+    expect(backup.data.environments).toHaveLength(1);
+    expect(backup.data.environments[0].name).toBe('Seeded Env');
+
+    // Close modal
+    await page.locator('.fixed button:has-text("Close")').click();
+
+    // ─── Wipe state and import via Replace mode ────────────────────────────
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Confirm data was wiped
+    await expect(page.getByText('Seeded Collection')).not.toBeVisible();
+
+    // Open Backup modal → Import tab
+    await page.locator('button[title="Backup & Restore all data"]').click();
+    await page.locator('.fixed button:has-text("Import")').first().click();
+
+    // Paste backup JSON into the textarea
+    await page.locator('textarea[placeholder*="CurlIt backup"]').fill(contents);
+
+    // Validate (shows the preview panel)
+    await page.locator('button:has-text("Validate")').click();
+    await expect(page.getByText('Backup contents:')).toBeVisible();
+
+    // Switch to Replace mode and confirm the dialog
+    page.on('dialog', dialog => dialog.accept());
+    await page.locator('button:has-text("Replace"):has-text("Overwrite")').click();
+    await page.locator('button:has-text("Replace All")').click();
+
+    // Modal should close
+    await expect(page.getByRole('heading', { name: 'Backup & Restore' })).not.toBeVisible();
+
+    // ─── Verify state was restored ─────────────────────────────────────────
+    await expect(page.getByText('Seeded Collection')).toBeVisible();
+
+    // Environments tab should also have the seeded env
+    await page.locator('button[title="Environments"]').click();
+    await expect(page.getByText('Seeded Env')).toBeVisible();
+  });
+
+  test('invalid JSON shows an error on Validate', async ({ page }) => {
+    await page.locator('button[title="Backup & Restore all data"]').click();
+    await page.locator('.fixed button:has-text("Import")').first().click();
+
+    await page.locator('textarea[placeholder*="CurlIt backup"]').fill('{"not":"a backup"}');
+    await page.locator('button:has-text("Validate")').click();
+
+    await expect(page.getByText(/valid CurlIt backup/)).toBeVisible();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   GripHorizontal,
   Sun,
   Moon,
+  Archive,
 } from 'lucide-react';
 import { useAppStore } from './store';
 import { RequestTabs } from './components/RequestTabs';
@@ -22,6 +23,7 @@ import { CurlImportModal } from './components/CurlImportModal';
 import { CurlExportModal } from './components/CurlExportModal';
 import { OpenApiImportModal } from './components/OpenApiImportModal';
 import { SaveRequestModal } from './components/SaveRequestModal';
+import { BackupModal } from './components/BackupModal';
 import { useResizable } from './hooks/useResizable';
 import { disconnectWebSocket } from './utils/websocket';
 
@@ -42,6 +44,7 @@ function App() {
   const [showCurlExport, setShowCurlExport] = useState(false);
   const [showOpenApiImport, setShowOpenApiImport] = useState(false);
   const [showSaveModal, setShowSaveModal] = useState(false);
+  const [showBackup, setShowBackup] = useState(false);
 
   const activeTab = tabs.find(t => t.id === activeTabId);
   const activeRequest = activeTab ? requests[activeTab.requestId] : null;
@@ -156,6 +159,14 @@ function App() {
           )}
 
           <button
+            onClick={() => setShowBackup(true)}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-dark-300 hover:text-dark-100 bg-dark-700 hover:bg-dark-600 rounded-md transition-colors cursor-pointer"
+            title="Backup & Restore all data"
+          >
+            <Archive size={13} />
+            Backup
+          </button>
+          <button
             onClick={() => setShowOpenApiImport(true)}
             className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-dark-300 hover:text-dark-100 bg-dark-700 hover:bg-dark-600 rounded-md transition-colors cursor-pointer"
             title="Import OpenAPI / Swagger"
@@ -259,6 +270,7 @@ function App() {
       <CurlExportModal open={showCurlExport} onClose={() => setShowCurlExport(false)} request={activeRequest} />
       <OpenApiImportModal open={showOpenApiImport} onClose={() => setShowOpenApiImport(false)} />
       <SaveRequestModal open={showSaveModal} onClose={() => setShowSaveModal(false)} />
+      <BackupModal open={showBackup} onClose={() => setShowBackup(false)} />
     </div>
   );
 }

--- a/src/components/BackupModal.tsx
+++ b/src/components/BackupModal.tsx
@@ -1,0 +1,298 @@
+import { useRef, useState } from 'react';
+import { X, Archive, Download, Upload, AlertTriangle } from 'lucide-react';
+import { useAppStore } from '../store';
+import {
+  createBackup,
+  downloadBackup,
+  parseBackup,
+  type BackupData,
+  type ImportMode,
+} from '../utils/backup';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Tab = 'export' | 'import';
+
+export function BackupModal({ open, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>('export');
+  const [importText, setImportText] = useState('');
+  const [importError, setImportError] = useState<string | null>(null);
+  const [mode, setMode] = useState<ImportMode>('merge');
+  const [pendingBackup, setPendingBackup] = useState<BackupData | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const collections = useAppStore(s => s.collections);
+  const environments = useAppStore(s => s.environments);
+  const history = useAppStore(s => s.history);
+
+  if (!open) return null;
+
+  const totalRequests = collections.reduce((sum, c) => sum + c.requests.length, 0);
+
+  const reset = () => {
+    setImportText('');
+    setImportError(null);
+    setPendingBackup(null);
+    setMode('merge');
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleExport = () => {
+    const snapshot = useAppStore.getState().getBackupSnapshot();
+    const backup = createBackup(snapshot, '1.0.0');
+    downloadBackup(backup);
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setImportText(String(reader.result ?? ''));
+      setImportError(null);
+      setPendingBackup(null);
+    };
+    reader.readAsText(file);
+  };
+
+  const handleValidate = () => {
+    try {
+      const backup = parseBackup(importText);
+      setPendingBackup(backup);
+      setImportError(null);
+    } catch (err) {
+      setPendingBackup(null);
+      setImportError(err instanceof Error ? err.message : 'Invalid backup file');
+    }
+  };
+
+  const handleConfirmImport = () => {
+    if (!pendingBackup) return;
+    if (mode === 'replace') {
+      const ok = confirm(
+        'Replace all data? This will delete your current collections, environments, and history.'
+      );
+      if (!ok) return;
+    }
+    useAppStore.getState().importBackup(pendingBackup, mode);
+    handleClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-dark-800 border border-dark-600 rounded-xl shadow-2xl w-full max-w-lg mx-4">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-dark-600">
+          <div className="flex items-center gap-2">
+            <Archive size={16} className="text-accent-blue" />
+            <h3 className="text-sm font-semibold text-dark-100">Backup &amp; Restore</h3>
+          </div>
+          <button
+            onClick={handleClose}
+            className="p-1 text-dark-400 hover:text-dark-200 rounded cursor-pointer"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex border-b border-dark-600">
+          <button
+            onClick={() => setTab('export')}
+            className={`flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-medium transition-colors cursor-pointer ${
+              tab === 'export'
+                ? 'text-dark-100 border-b-2 border-accent-blue bg-dark-800/50'
+                : 'text-dark-400 hover:text-dark-200'
+            }`}
+          >
+            <Download size={14} />
+            Export
+          </button>
+          <button
+            onClick={() => setTab('import')}
+            className={`flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-medium transition-colors cursor-pointer ${
+              tab === 'import'
+                ? 'text-dark-100 border-b-2 border-accent-blue bg-dark-800/50'
+                : 'text-dark-400 hover:text-dark-200'
+            }`}
+          >
+            <Upload size={14} />
+            Import
+          </button>
+        </div>
+
+        {tab === 'export' ? (
+          <div className="p-4">
+            <p className="text-xs text-dark-300 mb-3">
+              Download a single JSON file containing all your data.
+            </p>
+            <div className="bg-dark-900 border border-dark-600 rounded-lg p-3 mb-3">
+              <div className="grid grid-cols-3 gap-3 text-center">
+                <Stat label="Collections" value={collections.length} />
+                <Stat label="Requests" value={totalRequests} />
+                <Stat label="Environments" value={environments.length} />
+              </div>
+              <div className="mt-3 pt-3 border-t border-dark-700 text-[11px] text-dark-400 text-center">
+                {history.length} history {history.length === 1 ? 'entry' : 'entries'} also included
+              </div>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={handleClose}
+                className="px-4 py-2 text-sm text-dark-300 hover:text-dark-100 bg-dark-700 rounded-lg cursor-pointer"
+              >
+                Close
+              </button>
+              <button
+                onClick={handleExport}
+                className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-accent-blue hover:bg-accent-blue/80 rounded-lg cursor-pointer"
+              >
+                <Download size={14} />
+                Download Backup
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-dark-200 bg-dark-700 hover:bg-dark-600 rounded cursor-pointer"
+              >
+                <Upload size={12} />
+                Choose File
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json,.json"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+              <span className="text-[11px] text-dark-500">or paste JSON below</span>
+            </div>
+
+            <textarea
+              value={importText}
+              onChange={e => {
+                setImportText(e.target.value);
+                setPendingBackup(null);
+                setImportError(null);
+              }}
+              placeholder="Paste CurlIt backup JSON here..."
+              className="w-full h-32 bg-dark-700 border border-dark-600 rounded-lg p-3 text-xs text-dark-200 font-mono placeholder:text-dark-500 resize-none"
+            />
+
+            {importError && (
+              <div className="mt-2 flex items-start gap-2 px-3 py-2 bg-accent-red/10 border border-accent-red/30 rounded text-xs text-accent-red">
+                <AlertTriangle size={12} className="mt-0.5 flex-shrink-0" />
+                <span>{importError}</span>
+              </div>
+            )}
+
+            {pendingBackup && (
+              <div className="mt-3 p-3 bg-dark-900 border border-dark-600 rounded-lg">
+                <div className="text-[11px] text-dark-400 mb-2">Backup contents:</div>
+                <div className="grid grid-cols-3 gap-3 text-center">
+                  <Stat label="Collections" value={pendingBackup.data.collections.length} />
+                  <Stat
+                    label="Requests"
+                    value={pendingBackup.data.collections.reduce(
+                      (sum, c) => sum + c.requests.length,
+                      0
+                    )}
+                  />
+                  <Stat label="Environments" value={pendingBackup.data.environments.length} />
+                </div>
+              </div>
+            )}
+
+            <div className="mt-3">
+              <div className="text-[11px] text-dark-400 mb-1.5">Import mode:</div>
+              <div className="flex gap-2">
+                <ModeButton
+                  selected={mode === 'merge'}
+                  onClick={() => setMode('merge')}
+                  label="Merge"
+                  description="Add to existing data"
+                />
+                <ModeButton
+                  selected={mode === 'replace'}
+                  onClick={() => setMode('replace')}
+                  label="Replace"
+                  description="Overwrite everything"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 mt-4">
+              <button
+                onClick={handleClose}
+                className="px-4 py-2 text-sm text-dark-300 hover:text-dark-100 bg-dark-700 rounded-lg cursor-pointer"
+              >
+                Cancel
+              </button>
+              {pendingBackup ? (
+                <button
+                  onClick={handleConfirmImport}
+                  className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-accent-blue hover:bg-accent-blue/80 rounded-lg cursor-pointer"
+                >
+                  <Upload size={14} />
+                  {mode === 'replace' ? 'Replace All' : 'Merge Backup'}
+                </button>
+              ) : (
+                <button
+                  onClick={handleValidate}
+                  disabled={!importText.trim()}
+                  className="px-4 py-2 text-sm text-white bg-accent-blue hover:bg-accent-blue/80 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg cursor-pointer"
+                >
+                  Validate
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <div className="text-lg font-semibold text-dark-100">{value}</div>
+      <div className="text-[10px] text-dark-400 uppercase tracking-wider">{label}</div>
+    </div>
+  );
+}
+
+function ModeButton({
+  selected,
+  onClick,
+  label,
+  description,
+}: {
+  selected: boolean;
+  onClick: () => void;
+  label: string;
+  description: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex-1 text-left px-3 py-2 rounded-lg cursor-pointer transition-colors border ${
+        selected
+          ? 'bg-accent-blue/20 border-accent-blue/40 text-dark-100'
+          : 'bg-dark-700 border-transparent text-dark-300 hover:bg-dark-600'
+      }`}
+    >
+      <div className="text-xs font-medium">{label}</div>
+      <div className="text-[10px] text-dark-400">{description}</div>
+    </button>
+  );
+}

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useAppStore } from '../index';
 import { createDefaultRequest } from '../../types';
+import { createBackup } from '../../utils/backup';
 
 // Reset store between tests
 function resetStore() {
@@ -367,6 +368,111 @@ describe('Save Active Request', () => {
     expect(tab.collectionId).toBe('col-123');
     expect(tab.sourceRequestId).toBe('req-456');
     expect(tab.isModified).toBe(false);
+  });
+});
+
+// ─── Backup / Restore ────────────────────────────────────────────────────────
+
+describe('Backup / Restore', () => {
+  it('getBackupSnapshot returns all persistent state', () => {
+    useAppStore.getState().createCollection('My Col');
+    useAppStore.getState().createEnvironment('Dev');
+    useAppStore.getState().addToHistory(createDefaultRequest({ url: 'https://h.com' }), null);
+    useAppStore.getState().updateChainVariables({ token: 'abc' });
+
+    const snapshot = useAppStore.getState().getBackupSnapshot();
+    expect(snapshot.collections).toHaveLength(1);
+    expect(snapshot.environments).toHaveLength(1);
+    expect(snapshot.history).toHaveLength(1);
+    expect(snapshot.chainVariables).toEqual({ token: 'abc' });
+    expect(snapshot.theme).toBe('dark');
+  });
+
+  it('importBackup in replace mode overwrites data and persists to localStorage', () => {
+    useAppStore.getState().createCollection('Old');
+    useAppStore.getState().createEnvironment('Old Env');
+
+    const backup = createBackup({
+      collections: [{ id: 'c1', name: 'Imported', requests: [], createdAt: 1, updatedAt: 1 }],
+      environments: [{ id: 'e1', name: 'Imported Env', variables: [], isActive: false }],
+      activeEnvironmentId: 'e1',
+      history: [],
+      chainVariables: { key: 'val' },
+      theme: 'light',
+    });
+
+    useAppStore.getState().importBackup(backup, 'replace');
+
+    const state = useAppStore.getState();
+    expect(state.collections).toHaveLength(1);
+    expect(state.collections[0].name).toBe('Imported');
+    expect(state.environments).toHaveLength(1);
+    expect(state.environments[0].name).toBe('Imported Env');
+    expect(state.activeEnvironmentId).toBe('e1');
+    expect(state.chainVariables).toEqual({ key: 'val' });
+    expect(state.theme).toBe('light');
+
+    // Persisted
+    expect(JSON.parse(localStorage.getItem('curlit_collections')!)).toHaveLength(1);
+    expect(JSON.parse(localStorage.getItem('curlit_environments')!)).toHaveLength(1);
+    expect(JSON.parse(localStorage.getItem('curlit_active_env')!)).toBe('e1');
+    expect(JSON.parse(localStorage.getItem('curlit_chain_vars')!)).toEqual({ key: 'val' });
+    expect(JSON.parse(localStorage.getItem('curlit_theme')!)).toBe('light');
+  });
+
+  it('importBackup in merge mode appends without overwriting existing data', () => {
+    useAppStore.getState().createCollection('Existing');
+    useAppStore.getState().createEnvironment('Existing Env');
+    const existingEnvId = useAppStore.getState().environments[0].id;
+    useAppStore.getState().setActiveEnvironment(existingEnvId);
+
+    const backup = createBackup({
+      collections: [{ id: 'c1', name: 'Imported', requests: [], createdAt: 1, updatedAt: 1 }],
+      environments: [{ id: 'e1', name: 'Imported Env', variables: [], isActive: false }],
+      activeEnvironmentId: 'e1',
+      history: [],
+      chainVariables: {},
+      theme: 'light',
+    });
+
+    useAppStore.getState().importBackup(backup, 'merge');
+
+    const state = useAppStore.getState();
+    expect(state.collections).toHaveLength(2);
+    expect(state.environments).toHaveLength(2);
+    expect(state.activeEnvironmentId).toBe(existingEnvId);
+    // Merge preserves current theme
+    expect(state.theme).toBe('dark');
+  });
+
+  it('importBackup strips scripts for safety', () => {
+    const backup = createBackup({
+      collections: [
+        {
+          id: 'c1',
+          name: 'Imported',
+          requests: [
+            {
+              ...createDefaultRequest({ name: 'Scripted' }),
+              preRequestScript: 'alert(1)',
+              testScript: 'console.log("test")',
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      environments: [],
+      activeEnvironmentId: null,
+      history: [],
+      chainVariables: {},
+      theme: 'dark',
+    });
+
+    useAppStore.getState().importBackup(backup, 'replace');
+    const req = useAppStore.getState().collections[0].requests[0];
+    expect(req.preRequestScript).toBeUndefined();
+    expect(req.testScript).toBeUndefined();
   });
 });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -15,6 +15,8 @@ import type {
 } from '../types';
 import { createDefaultRequest, createDefaultWebSocketSession } from '../types';
 import { removeFilesForRequest } from '../utils/fileStore';
+import type { BackupData, BackupSnapshot, ImportMode } from '../utils/backup';
+import { applyBackup } from '../utils/backup';
 
 const STORAGE_KEYS = {
   collections: 'curlit_collections',
@@ -125,6 +127,10 @@ interface AppState {
   // Actions - Save
   saveActiveRequest: () => 'saved' | 'needs-collection';
   markTabSaved: (tabId: string, collectionId: string, sourceRequestId: string) => void;
+
+  // Actions - Backup
+  getBackupSnapshot: () => BackupSnapshot;
+  importBackup: (backup: BackupData, mode: ImportMode) => void;
 
   // Actions - UI
   setTheme: (theme: Theme) => void;
@@ -592,6 +598,52 @@ export const useAppStore = create<AppState>((set, get) => ({
         t.id === tabId ? { ...t, collectionId, sourceRequestId, isModified: false } : t
       ),
     }));
+  },
+
+  // Backup actions
+  getBackupSnapshot: () => {
+    const state = get();
+    return {
+      collections: state.collections,
+      environments: state.environments,
+      activeEnvironmentId: state.activeEnvironmentId,
+      history: state.history,
+      chainVariables: state.chainVariables,
+      theme: state.theme,
+    };
+  },
+
+  importBackup: (backup, mode) => {
+    const state = get();
+    const current: BackupSnapshot = {
+      collections: state.collections,
+      environments: state.environments,
+      activeEnvironmentId: state.activeEnvironmentId,
+      history: state.history,
+      chainVariables: state.chainVariables,
+      theme: state.theme,
+    };
+    const next = applyBackup(current, backup, mode);
+
+    saveToStorage(STORAGE_KEYS.collections, next.collections);
+    saveToStorage(STORAGE_KEYS.environments, next.environments);
+    saveToStorage(STORAGE_KEYS.activeEnv, next.activeEnvironmentId);
+    saveToStorage(STORAGE_KEYS.history, next.history);
+    saveToStorage(STORAGE_KEYS.chainVariables, next.chainVariables);
+    saveToStorage(STORAGE_KEYS.theme, next.theme);
+
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-theme', next.theme);
+    }
+
+    set({
+      collections: next.collections,
+      environments: next.environments,
+      activeEnvironmentId: next.activeEnvironmentId,
+      history: next.history,
+      chainVariables: next.chainVariables,
+      theme: next.theme,
+    });
   },
 
   // UI actions

--- a/src/utils/__tests__/backup.test.ts
+++ b/src/utils/__tests__/backup.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BACKUP_VERSION,
+  applyBackup,
+  createBackup,
+  isBackup,
+  parseBackup,
+  type BackupData,
+  type BackupSnapshot,
+} from '../backup';
+import { createDefaultRequest } from '../../types';
+import type { Collection, Environment, HistoryEntry } from '../../types';
+
+function emptySnapshot(): BackupSnapshot {
+  return {
+    collections: [],
+    environments: [],
+    activeEnvironmentId: null,
+    history: [],
+    chainVariables: {},
+    theme: 'dark',
+  };
+}
+
+function sampleCollection(name = 'Col'): Collection {
+  return {
+    id: crypto.randomUUID(),
+    name,
+    requests: [createDefaultRequest({ name: 'Req' })],
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function sampleEnvironment(name = 'Env'): Environment {
+  return {
+    id: crypto.randomUUID(),
+    name,
+    variables: [{ id: '1', key: 'host', value: 'api.test', enabled: true }],
+    isActive: false,
+  };
+}
+
+function sampleHistoryEntry(url = 'https://example.com'): HistoryEntry {
+  return {
+    id: crypto.randomUUID(),
+    request: createDefaultRequest({ url }),
+    response: null,
+    timestamp: Date.now(),
+  };
+}
+
+// ─── createBackup ────────────────────────────────────────────────────────────
+
+describe('createBackup', () => {
+  it('wraps snapshot with versioned envelope', () => {
+    const snapshot = emptySnapshot();
+    const backup = createBackup(snapshot);
+    expect(backup.curlit_backup_version).toBe(BACKUP_VERSION);
+    expect(typeof backup.exported_at).toBe('number');
+    expect(backup.data).toEqual(snapshot);
+  });
+
+  it('includes app version when provided', () => {
+    const backup = createBackup(emptySnapshot(), '1.2.3');
+    expect(backup.app_version).toBe('1.2.3');
+  });
+});
+
+// ─── isBackup ────────────────────────────────────────────────────────────────
+
+describe('isBackup', () => {
+  it('accepts valid backup', () => {
+    const backup = createBackup(emptySnapshot());
+    expect(isBackup(backup)).toBe(true);
+  });
+
+  it('rejects null/undefined/primitives', () => {
+    expect(isBackup(null)).toBe(false);
+    expect(isBackup(undefined)).toBe(false);
+    expect(isBackup('string')).toBe(false);
+    expect(isBackup(42)).toBe(false);
+  });
+
+  it('rejects postman-style object', () => {
+    expect(isBackup({ info: { name: 'X' }, item: [] })).toBe(false);
+  });
+
+  it('rejects object missing required fields', () => {
+    expect(isBackup({ curlit_backup_version: 1 })).toBe(false);
+    expect(isBackup({ curlit_backup_version: 1, data: {} })).toBe(false);
+  });
+});
+
+// ─── parseBackup ─────────────────────────────────────────────────────────────
+
+describe('parseBackup', () => {
+  it('parses valid backup JSON', () => {
+    const backup = createBackup(emptySnapshot());
+    const parsed = parseBackup(JSON.stringify(backup));
+    expect(parsed.curlit_backup_version).toBe(BACKUP_VERSION);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseBackup('not json')).toThrow();
+  });
+
+  it('throws on well-formed JSON that is not a backup', () => {
+    expect(() => parseBackup('{"foo":"bar"}')).toThrow(/valid CurlIt backup/);
+  });
+
+  it('throws on a future backup version', () => {
+    const backup = createBackup(emptySnapshot());
+    const future = { ...backup, curlit_backup_version: BACKUP_VERSION + 99 };
+    expect(() => parseBackup(JSON.stringify(future))).toThrow(/newer version/);
+  });
+});
+
+// ─── applyBackup: replace mode ───────────────────────────────────────────────
+
+describe('applyBackup replace mode', () => {
+  it('overwrites current snapshot entirely', () => {
+    const current: BackupSnapshot = {
+      collections: [sampleCollection('Old')],
+      environments: [sampleEnvironment('OldEnv')],
+      activeEnvironmentId: 'old-id',
+      history: [sampleHistoryEntry('https://old.com')],
+      chainVariables: { old: 'value' },
+      theme: 'light',
+    };
+
+    const incomingCol = sampleCollection('New');
+    const incomingEnv = sampleEnvironment('NewEnv');
+    const backup: BackupData = createBackup({
+      collections: [incomingCol],
+      environments: [incomingEnv],
+      activeEnvironmentId: incomingEnv.id,
+      history: [sampleHistoryEntry('https://new.com')],
+      chainVariables: { fresh: 'v' },
+      theme: 'dark',
+    });
+
+    const result = applyBackup(current, backup, 'replace');
+    expect(result.collections).toHaveLength(1);
+    expect(result.collections[0].name).toBe('New');
+    expect(result.environments[0].name).toBe('NewEnv');
+    expect(result.activeEnvironmentId).toBe(incomingEnv.id);
+    expect(result.history[0].request.url).toBe('https://new.com');
+    expect(result.chainVariables).toEqual({ fresh: 'v' });
+    expect(result.theme).toBe('dark');
+  });
+
+  it('strips pre-request and test scripts from incoming requests', () => {
+    const col = sampleCollection();
+    col.requests[0].preRequestScript = 'alert(1)';
+    col.requests[0].testScript = 'console.log("test")';
+    const backup = createBackup({ ...emptySnapshot(), collections: [col] });
+    const result = applyBackup(emptySnapshot(), backup, 'replace');
+    expect(result.collections[0].requests[0].preRequestScript).toBeUndefined();
+    expect(result.collections[0].requests[0].testScript).toBeUndefined();
+  });
+
+  it('caps history at 100 entries', () => {
+    const manyEntries = Array.from({ length: 150 }, (_, i) => sampleHistoryEntry(`https://e${i}.com`));
+    const backup = createBackup({ ...emptySnapshot(), history: manyEntries });
+    const result = applyBackup(emptySnapshot(), backup, 'replace');
+    expect(result.history).toHaveLength(100);
+  });
+});
+
+// ─── applyBackup: merge mode ─────────────────────────────────────────────────
+
+describe('applyBackup merge mode', () => {
+  it('appends incoming collections with new IDs', () => {
+    const existing = sampleCollection('Existing');
+    const current: BackupSnapshot = { ...emptySnapshot(), collections: [existing] };
+    const incoming = sampleCollection('Incoming');
+    const incomingReqId = incoming.requests[0].id;
+    const backup = createBackup({ ...emptySnapshot(), collections: [incoming] });
+
+    const result = applyBackup(current, backup, 'merge');
+    expect(result.collections).toHaveLength(2);
+    expect(result.collections[0].name).toBe('Existing');
+    expect(result.collections[1].name).toBe('Incoming');
+    expect(result.collections[1].id).not.toBe(incoming.id);
+    expect(result.collections[1].requests[0].id).not.toBe(incomingReqId);
+  });
+
+  it('appends environments with new IDs and keeps current active env', () => {
+    const existing = sampleEnvironment('Existing');
+    const current: BackupSnapshot = {
+      ...emptySnapshot(),
+      environments: [existing],
+      activeEnvironmentId: existing.id,
+    };
+    const incoming = sampleEnvironment('Incoming');
+    const backup = createBackup({
+      ...emptySnapshot(),
+      environments: [incoming],
+      activeEnvironmentId: incoming.id,
+    });
+
+    const result = applyBackup(current, backup, 'merge');
+    expect(result.environments).toHaveLength(2);
+    expect(result.environments[1].id).not.toBe(incoming.id);
+    expect(result.activeEnvironmentId).toBe(existing.id);
+  });
+
+  it('merges history with incoming first, capped at 100', () => {
+    const currentEntries = Array.from({ length: 60 }, (_, i) => sampleHistoryEntry(`https://cur${i}.com`));
+    const incomingEntries = Array.from({ length: 60 }, (_, i) => sampleHistoryEntry(`https://inc${i}.com`));
+    const current: BackupSnapshot = { ...emptySnapshot(), history: currentEntries };
+    const backup = createBackup({ ...emptySnapshot(), history: incomingEntries });
+
+    const result = applyBackup(current, backup, 'merge');
+    expect(result.history).toHaveLength(100);
+    expect(result.history[0].request.url).toBe('https://inc0.com');
+  });
+
+  it('merges chain variables with incoming taking precedence', () => {
+    const current: BackupSnapshot = {
+      ...emptySnapshot(),
+      chainVariables: { a: 'old', b: 'keep' },
+    };
+    const backup = createBackup({
+      ...emptySnapshot(),
+      chainVariables: { a: 'new', c: 'added' },
+    });
+    const result = applyBackup(current, backup, 'merge');
+    expect(result.chainVariables).toEqual({ a: 'new', b: 'keep', c: 'added' });
+  });
+
+  it('preserves current theme in merge mode', () => {
+    const current: BackupSnapshot = { ...emptySnapshot(), theme: 'light' };
+    const backup = createBackup({ ...emptySnapshot(), theme: 'dark' });
+    const result = applyBackup(current, backup, 'merge');
+    expect(result.theme).toBe('light');
+  });
+
+  it('strips scripts from merged collections', () => {
+    const incoming = sampleCollection('With Script');
+    incoming.requests[0].preRequestScript = 'alert(1)';
+    const backup = createBackup({ ...emptySnapshot(), collections: [incoming] });
+    const result = applyBackup(emptySnapshot(), backup, 'merge');
+    expect(result.collections[0].requests[0].preRequestScript).toBeUndefined();
+  });
+});

--- a/src/utils/backup.ts
+++ b/src/utils/backup.ts
@@ -1,0 +1,148 @@
+import type { Collection, Environment, HistoryEntry, RequestConfig } from '../types';
+import type { Theme } from '../store';
+
+export const BACKUP_VERSION = 1;
+
+export interface BackupData {
+  curlit_backup_version: number;
+  exported_at: number;
+  app_version?: string;
+  data: {
+    collections: Collection[];
+    environments: Environment[];
+    activeEnvironmentId: string | null;
+    history: HistoryEntry[];
+    chainVariables: Record<string, string>;
+    theme: Theme;
+  };
+}
+
+export interface BackupSnapshot {
+  collections: Collection[];
+  environments: Environment[];
+  activeEnvironmentId: string | null;
+  history: HistoryEntry[];
+  chainVariables: Record<string, string>;
+  theme: Theme;
+}
+
+export function createBackup(snapshot: BackupSnapshot, appVersion?: string): BackupData {
+  return {
+    curlit_backup_version: BACKUP_VERSION,
+    exported_at: Date.now(),
+    app_version: appVersion,
+    data: {
+      collections: snapshot.collections,
+      environments: snapshot.environments,
+      activeEnvironmentId: snapshot.activeEnvironmentId,
+      history: snapshot.history,
+      chainVariables: snapshot.chainVariables,
+      theme: snapshot.theme,
+    },
+  };
+}
+
+export function isBackup(obj: unknown): obj is BackupData {
+  if (!obj || typeof obj !== 'object') return false;
+  const b = obj as Partial<BackupData>;
+  if (typeof b.curlit_backup_version !== 'number') return false;
+  if (!b.data || typeof b.data !== 'object') return false;
+  const d = b.data;
+  return (
+    Array.isArray(d.collections) &&
+    Array.isArray(d.environments) &&
+    Array.isArray(d.history) &&
+    typeof d.chainVariables === 'object' &&
+    d.chainVariables !== null
+  );
+}
+
+export function parseBackup(text: string): BackupData {
+  const parsed = JSON.parse(text);
+  if (!isBackup(parsed)) {
+    throw new Error('Not a valid CurlIt backup file');
+  }
+  if (parsed.curlit_backup_version > BACKUP_VERSION) {
+    throw new Error(
+      `Backup was created with a newer version (v${parsed.curlit_backup_version}). Update CurlIt to import it.`
+    );
+  }
+  return parsed;
+}
+
+/** Strip pre-request/test scripts from requests to prevent code execution from untrusted backups. */
+function stripScripts(request: RequestConfig): RequestConfig {
+  const cleaned = { ...request };
+  delete cleaned.preRequestScript;
+  delete cleaned.testScript;
+  return cleaned;
+}
+
+function sanitizeCollections(collections: Collection[]): Collection[] {
+  return collections.map(c => ({ ...c, requests: c.requests.map(stripScripts) }));
+}
+
+export type ImportMode = 'replace' | 'merge';
+
+/**
+ * Compute the new snapshot after applying a backup to the current state.
+ * In 'replace' mode, existing data is discarded. In 'merge' mode, incoming
+ * collections/environments get fresh IDs so they do not collide with existing ones.
+ */
+export function applyBackup(
+  current: BackupSnapshot,
+  backup: BackupData,
+  mode: ImportMode
+): BackupSnapshot {
+  const incoming = backup.data;
+  const safeCollections = sanitizeCollections(incoming.collections);
+
+  if (mode === 'replace') {
+    return {
+      collections: safeCollections,
+      environments: incoming.environments,
+      activeEnvironmentId: incoming.activeEnvironmentId ?? null,
+      history: incoming.history.slice(0, 100),
+      chainVariables: { ...incoming.chainVariables },
+      theme: incoming.theme || current.theme,
+    };
+  }
+
+  // Merge mode: regenerate IDs on incoming collections/environments to avoid collisions.
+  const mergedCollections: Collection[] = [
+    ...current.collections,
+    ...safeCollections.map(c => ({
+      ...c,
+      id: crypto.randomUUID(),
+      requests: c.requests.map(r => ({ ...r, id: crypto.randomUUID() })),
+    })),
+  ];
+
+  const mergedEnvironments: Environment[] = [
+    ...current.environments,
+    ...incoming.environments.map(e => ({ ...e, id: crypto.randomUUID() })),
+  ];
+
+  const mergedHistory = [...incoming.history, ...current.history].slice(0, 100);
+
+  return {
+    collections: mergedCollections,
+    environments: mergedEnvironments,
+    activeEnvironmentId: current.activeEnvironmentId,
+    history: mergedHistory,
+    chainVariables: { ...current.chainVariables, ...incoming.chainVariables },
+    theme: current.theme,
+  };
+}
+
+export function downloadBackup(backup: BackupData, filename?: string): void {
+  const data = JSON.stringify(backup, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  const date = new Date(backup.exported_at).toISOString().split('T')[0];
+  a.download = filename || `curlit-backup-${date}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- Adds a versioned backup envelope that bundles collections, environments (with active selection), history, chain variables, and theme into a single JSON file.
- New **Backup & Restore** modal in the header with Export (download `curlit-backup-YYYY-MM-DD.json`) and Import tabs. Import supports **Merge** (append with fresh UUIDs, default) and **Replace** (overwrite after confirmation).
- Pre-request and test scripts are stripped from imported requests, matching the existing collection import safety posture.
- Implements the `v1.3` roadmap item `Export/import all data (full backup as single JSON)`.

## Test plan
- [x] 19 unit tests for the backup utility (`src/utils/__tests__/backup.test.ts`) cover the envelope, validation, version gating, replace-mode overwrite, merge-mode ID regeneration, history capping, script stripping.
- [x] 4 store tests for `getBackupSnapshot` and `importBackup` across both modes, including localStorage persistence.
- [x] 2 Playwright e2e specs (`e2e/backup.spec.ts`): end-to-end export-download-wipe-import round trip, and invalid-JSON validation error.
- [x] Full suite: `npm test -- --run` -> 367 passed.
- [x] Manual smoke test: seed data -> export -> clear localStorage -> import (Merge and Replace) -> verify state restores.