### PR TITLE
Add shareable request links encoded in URL

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,7 +54,7 @@
 ### v1.3 -- Collaboration & Sync
 
 - [x] Export/import all data (full backup as single JSON)
-- [ ] Shareable request links (encoded in URL)
+- [x] Shareable request links (encoded in URL)
 - [ ] Optional cloud sync via GitHub Gist or a self-hosted backend
 - [ ] Team workspaces with shared collections
 - [ ] Real-time collaboration (conflict-free editing)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -195,6 +195,31 @@ Pre-request and test scripts are stripped from imported requests as a safety mea
 
 ---
 
+## Sharing Requests by Link
+
+Encode the current request into a URL you can share in chat, docs, or tickets. The recipient clicks the link and the request opens in a new tab.
+
+### Generating a Share Link
+
+1. Click **Share** in the header
+2. By default, the link excludes **auth credentials** and **pre-request / test scripts**
+3. Click **Copy Link**
+
+### Including Secrets (Opt-In)
+
+Tick **Include secrets** to embed auth credentials and scripts in the link. The modal shows a warning when this is on -- the encoded payload becomes part of the URL, which means anywhere the link is pasted (chat, tickets, screenshots, browser history) carries those credentials.
+
+Leave this off unless you're sharing with someone you trust over a channel you trust.
+
+### How It Works
+
+- Everything is encoded in the URL fragment (`#share=...`) so the payload never reaches the proxy server or any HTTP logs.
+- Form-data file attachments can't travel through a URL; those fields are converted to empty text entries on the recipient side.
+- Incoming links always have pre-request / test scripts stripped on the import side, even if the sender opted in.
+- Links are capped by whatever your chat/email client will accept. For very large requests the modal shows a warning -- send a backup file instead.
+
+---
+
 ## cURL Integration
 
 ### Importing a cURL Command

--- a/e2e/share.spec.ts
+++ b/e2e/share.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Share Request Links', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('generate a share link, open it, and see the request restored', async ({ page }) => {
+    // ─── Configure the active request ──────────────────────────────────────
+    const urlInput = page.locator('input[placeholder*="Enter URL"]');
+    await urlInput.fill('https://api.example.com/shared');
+
+    // ─── Open Share modal ──────────────────────────────────────────────────
+    await page.locator('button[title="Share request as a link"]').click();
+    await expect(page.getByRole('heading', { name: 'Share Request' })).toBeVisible();
+
+    // ─── Grab the generated link ───────────────────────────────────────────
+    const linkTextarea = page.locator('textarea[readonly]');
+    const shareUrl = await linkTextarea.inputValue();
+    expect(shareUrl).toMatch(/#share=[A-Za-z0-9_-]+$/);
+
+    // ─── Visit the link ────────────────────────────────────────────────────
+    await page.goto(shareUrl);
+    await page.waitForLoadState('networkidle');
+
+    // URL bar of the newly opened tab should contain the shared URL
+    const restoredUrl = page.locator('input[placeholder*="Enter URL"]');
+    await expect(restoredUrl).toHaveValue('https://api.example.com/shared');
+
+    // Hash should be cleared after import so refresh doesn't re-import
+    await expect.poll(async () => page.evaluate(() => window.location.hash)).toBe('');
+  });
+
+  test('secrets are stripped by default, included when toggle is enabled', async ({ page }) => {
+    const urlInput = page.locator('input[placeholder*="Enter URL"]');
+    await urlInput.fill('https://api.example.com/secure');
+
+    // Navigate to the Auth tab and set a bearer token
+    await page.getByRole('button', { name: 'Auth', exact: true }).click();
+    await page.getByRole('button', { name: 'Bearer Token', exact: true }).click();
+    await page.locator('input[placeholder="Enter bearer token"]').fill('super-secret-token');
+
+    // Open the share modal
+    await page.locator('button[title="Share request as a link"]').click();
+
+    const decodeFn = (enc: string) => {
+      const pad = '='.repeat((4 - (enc.length % 4)) % 4);
+      const b64 = enc.replace(/-/g, '+').replace(/_/g, '/') + pad;
+      return JSON.parse(atob(b64));
+    };
+
+    // Default: toggle is off → no secret in the encoded link
+    const linkTextarea = page.locator('textarea[readonly]');
+    const defaultUrl = await linkTextarea.inputValue();
+    const defaultPayload = await page.evaluate(decodeFn, defaultUrl.split('#share=')[1]);
+    expect(defaultPayload.request.auth.type).toBe('none');
+    expect(defaultPayload.includesSecrets).toBe(false);
+
+    // Enable include secrets
+    await page.getByRole('checkbox').check();
+    await expect(page.getByText(/contains credentials and executable scripts/)).toBeVisible();
+
+    // The link now carries the bearer token
+    const secretUrl = await linkTextarea.inputValue();
+    const secretPayload = await page.evaluate(decodeFn, secretUrl.split('#share=')[1]);
+    expect(secretPayload.request.auth.type).toBe('bearer');
+    expect(secretPayload.request.auth.bearer.token).toBe('super-secret-token');
+    expect(secretPayload.includesSecrets).toBe(true);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   PanelLeftClose,
   PanelLeftOpen,
@@ -12,6 +12,7 @@ import {
   Sun,
   Moon,
   Archive,
+  Share2,
 } from 'lucide-react';
 import { useAppStore } from './store';
 import { RequestTabs } from './components/RequestTabs';
@@ -24,8 +25,10 @@ import { CurlExportModal } from './components/CurlExportModal';
 import { OpenApiImportModal } from './components/OpenApiImportModal';
 import { SaveRequestModal } from './components/SaveRequestModal';
 import { BackupModal } from './components/BackupModal';
+import { ShareRequestModal } from './components/ShareRequestModal';
 import { useResizable } from './hooks/useResizable';
 import { disconnectWebSocket } from './utils/websocket';
+import { readShareFromLocation, sharedRequestToTabSeed } from './utils/share';
 
 function App() {
   const activeTabId = useAppStore(s => s.activeTabId);
@@ -45,6 +48,7 @@ function App() {
   const [showOpenApiImport, setShowOpenApiImport] = useState(false);
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [showBackup, setShowBackup] = useState(false);
+  const [showShare, setShowShare] = useState(false);
 
   const activeTab = tabs.find(t => t.id === activeTabId);
   const activeRequest = activeTab ? requests[activeTab.requestId] : null;
@@ -124,6 +128,32 @@ function App() {
     return () => window.removeEventListener('beforeunload', cleanup);
   }, []);
 
+  // Open incoming shared request links (#share=...) as a new tab. Runs on
+  // mount and on hashchange (for same-tab navigations where the hash changes
+  // without a reload).
+  const initialShareProcessedRef = useRef(false);
+  useEffect(() => {
+    const importFromHash = () => {
+      try {
+        const payload = readShareFromLocation();
+        if (payload) {
+          useAppStore.getState().addTab(sharedRequestToTabSeed(payload));
+        }
+      } catch (err) {
+        alert(err instanceof Error ? err.message : 'Could not open share link');
+      }
+    };
+
+    // Mount-time check, guarded against React StrictMode double-invoke in dev
+    if (!initialShareProcessedRef.current) {
+      initialShareProcessedRef.current = true;
+      importFromHash();
+    }
+
+    window.addEventListener('hashchange', importFromHash);
+    return () => window.removeEventListener('hashchange', importFromHash);
+  }, []);
+
   return (
     <div className="flex flex-col h-full bg-dark-900">
       {/* Top bar */}
@@ -189,6 +219,15 @@ function App() {
           >
             <FileCode size={13} />
             Export cURL
+          </button>
+          <button
+            onClick={() => setShowShare(true)}
+            disabled={!activeRequest}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-dark-300 hover:text-dark-100 bg-dark-700 hover:bg-dark-600 rounded-md transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Share request as a link"
+          >
+            <Share2 size={13} />
+            Share
           </button>
         </div>
       </header>
@@ -271,6 +310,7 @@ function App() {
       <OpenApiImportModal open={showOpenApiImport} onClose={() => setShowOpenApiImport(false)} />
       <SaveRequestModal open={showSaveModal} onClose={() => setShowSaveModal(false)} />
       <BackupModal open={showBackup} onClose={() => setShowBackup(false)} />
+      <ShareRequestModal open={showShare} onClose={() => setShowShare(false)} request={activeRequest} />
     </div>
   );
 }

--- a/src/components/ShareRequestModal.tsx
+++ b/src/components/ShareRequestModal.tsx
@@ -1,0 +1,127 @@
+import { useMemo, useState } from 'react';
+import { X, Share2, Copy, Check, AlertTriangle } from 'lucide-react';
+import type { RequestConfig } from '../types';
+import { buildShareUrl, encodeRequest } from '../utils/share';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  request: RequestConfig | null;
+}
+
+const LONG_URL_THRESHOLD = 2000;
+
+export function ShareRequestModal({ open, onClose, request }: Props) {
+  const [includeSecrets, setIncludeSecrets] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const shareUrl = useMemo(() => {
+    if (!request) return '';
+    const encoded = encodeRequest(request, { includeSecrets });
+    return buildShareUrl(window.location.origin, encoded);
+  }, [request, includeSecrets]);
+
+  if (!open || !request) return null;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleClose = () => {
+    setIncludeSecrets(false);
+    setCopied(false);
+    onClose();
+  };
+
+  const urlSize = shareUrl.length;
+  const isLong = urlSize > LONG_URL_THRESHOLD;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-dark-800 border border-dark-600 rounded-xl shadow-2xl w-full max-w-lg mx-4">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-dark-600">
+          <div className="flex items-center gap-2">
+            <Share2 size={16} className="text-accent-blue" />
+            <h3 className="text-sm font-semibold text-dark-100">Share Request</h3>
+          </div>
+          <button
+            onClick={handleClose}
+            className="p-1 text-dark-400 hover:text-dark-200 rounded cursor-pointer"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="p-4">
+          <p className="text-xs text-dark-300 mb-3">
+            Anyone with this link can open the request in their CurlIt tab.
+          </p>
+
+          <label className="flex items-start gap-2 p-3 bg-dark-900 border border-dark-600 rounded-lg cursor-pointer">
+            <input
+              type="checkbox"
+              checked={includeSecrets}
+              onChange={e => setIncludeSecrets(e.target.checked)}
+              className="mt-0.5 cursor-pointer accent-accent-blue"
+            />
+            <div>
+              <div className="text-xs font-medium text-dark-100">Include secrets</div>
+              <div className="text-[11px] text-dark-400 mt-0.5">
+                Auth credentials and pre-request / test scripts. Off by default.
+              </div>
+            </div>
+          </label>
+
+          {includeSecrets && (
+            <div className="mt-2 flex items-start gap-2 px-3 py-2 bg-accent-red/10 border border-accent-red/30 rounded text-xs text-accent-red">
+              <AlertTriangle size={12} className="mt-0.5 flex-shrink-0" />
+              <span>
+                This link contains credentials and executable scripts. Share only with people
+                you trust, and don't paste it where it could be logged (chat, email, screenshots).
+              </span>
+            </div>
+          )}
+
+          <div className="mt-3">
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-[11px] text-dark-400 uppercase tracking-wider">Link</label>
+              <span className={`text-[11px] ${isLong ? 'text-accent-red' : 'text-dark-500'}`}>
+                {urlSize.toLocaleString()} chars
+              </span>
+            </div>
+            <textarea
+              readOnly
+              value={shareUrl}
+              onClick={e => (e.currentTarget as HTMLTextAreaElement).select()}
+              className="w-full h-24 bg-dark-700 border border-dark-600 rounded-lg p-3 text-[11px] text-dark-200 font-mono resize-none break-all"
+            />
+            {isLong && (
+              <div className="mt-1 text-[11px] text-accent-red">
+                This link is very long and may be truncated by some chat apps. Consider sharing
+                a backup file instead for large requests.
+              </div>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 mt-4">
+            <button
+              onClick={handleClose}
+              className="px-4 py-2 text-sm text-dark-300 hover:text-dark-100 bg-dark-700 rounded-lg cursor-pointer"
+            >
+              Close
+            </button>
+            <button
+              onClick={handleCopy}
+              className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-accent-blue hover:bg-accent-blue/80 rounded-lg cursor-pointer"
+            >
+              {copied ? <Check size={14} /> : <Copy size={14} />}
+              {copied ? 'Copied!' : 'Copy Link'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/utils/__tests__/share.test.ts
+++ b/src/utils/__tests__/share.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  SHARE_VERSION,
+  buildShareUrl,
+  decodePayload,
+  encodeRequest,
+  readShareFromLocation,
+  sharedRequestToTabSeed,
+} from '../share';
+import { createDefaultRequest, createFormDataEntry } from '../../types';
+import type { RequestConfig } from '../../types';
+
+function requestWithEverything(): RequestConfig {
+  return createDefaultRequest({
+    name: 'Full Request',
+    method: 'POST',
+    url: 'https://api.example.com/users',
+    params: [{ id: 'p1', key: 'q', value: 'search', enabled: true }],
+    headers: [{ id: 'h1', key: 'X-Trace', value: '123', enabled: true }],
+    body: { type: 'json', raw: '{"name":"alice"}', formData: [], urlencoded: [] },
+    auth: { type: 'bearer', bearer: { token: 'secret-token' } },
+    preRequestScript: 'pm.env.set("x", 1)',
+    testScript: 'pm.expect(res.status).toBe(200)',
+  });
+}
+
+// ─── encode/decode round-trip ────────────────────────────────────────────────
+
+describe('encodeRequest / decodePayload', () => {
+  it('round-trips a request', () => {
+    const req = createDefaultRequest({ name: 'Simple', url: 'https://example.com' });
+    const encoded = encodeRequest(req, { includeSecrets: false });
+    const payload = decodePayload(encoded);
+    expect(payload.v).toBe(SHARE_VERSION);
+    expect(payload.request.url).toBe('https://example.com');
+  });
+
+  it('handles unicode in request body', () => {
+    const req = createDefaultRequest({
+      body: { type: 'json', raw: '{"name":"こんにちは 👋"}', formData: [], urlencoded: [] },
+    });
+    const encoded = encodeRequest(req, { includeSecrets: false });
+    const payload = decodePayload(encoded);
+    expect(payload.request.body.raw).toBe('{"name":"こんにちは 👋"}');
+  });
+
+  it('produces URL-safe output (no +, /, or = padding)', () => {
+    // Body crafted to produce padding-requiring output
+    const req = createDefaultRequest({ url: 'a'.repeat(50) });
+    const encoded = encodeRequest(req, { includeSecrets: false });
+    expect(encoded).not.toMatch(/[+/=]/);
+  });
+});
+
+// ─── includeSecrets: false (default) ─────────────────────────────────────────
+
+describe('encodeRequest with includeSecrets=false', () => {
+  it('strips auth, preRequestScript, and testScript', () => {
+    const encoded = encodeRequest(requestWithEverything(), { includeSecrets: false });
+    const payload = decodePayload(encoded);
+    expect(payload.request.auth).toEqual({ type: 'none' });
+    expect(payload.request.preRequestScript).toBeUndefined();
+    expect(payload.request.testScript).toBeUndefined();
+    expect(payload.includesSecrets).toBe(false);
+  });
+
+  it('leaves non-secret fields intact', () => {
+    const encoded = encodeRequest(requestWithEverything(), { includeSecrets: false });
+    const payload = decodePayload(encoded);
+    expect(payload.request.url).toBe('https://api.example.com/users');
+    expect(payload.request.headers[0].key).toBe('X-Trace');
+    expect(payload.request.body.raw).toBe('{"name":"alice"}');
+  });
+});
+
+// ─── includeSecrets: true (opt-in) ───────────────────────────────────────────
+
+describe('encodeRequest with includeSecrets=true', () => {
+  it('keeps auth, preRequestScript, and testScript', () => {
+    const encoded = encodeRequest(requestWithEverything(), { includeSecrets: true });
+    const payload = decodePayload(encoded);
+    expect(payload.request.auth.type).toBe('bearer');
+    expect(payload.request.auth.bearer?.token).toBe('secret-token');
+    expect(payload.request.preRequestScript).toBe('pm.env.set("x", 1)');
+    expect(payload.request.testScript).toBe('pm.expect(res.status).toBe(200)');
+    expect(payload.includesSecrets).toBe(true);
+  });
+});
+
+// ─── form-data file stripping (always) ───────────────────────────────────────
+
+describe('encodeRequest with form-data files', () => {
+  it('converts file entries to empty text entries even when includeSecrets=true', () => {
+    const req = createDefaultRequest({
+      body: {
+        type: 'form-data',
+        raw: '',
+        formData: [
+          createFormDataEntry({ key: 'avatar', valueType: 'file', fileName: 'p.png', fileSize: 100, fileType: 'image/png' }),
+          createFormDataEntry({ key: 'note', value: 'hi', valueType: 'text' }),
+        ],
+        urlencoded: [],
+      },
+    });
+    const encoded = encodeRequest(req, { includeSecrets: true });
+    const payload = decodePayload(encoded);
+    const entries = payload.request.body.formData;
+    expect(entries[0].valueType).toBe('text');
+    expect(entries[0].value).toBe('');
+    expect(entries[0].fileName).toBeUndefined();
+    expect(entries[1].valueType).toBe('text');
+    expect(entries[1].value).toBe('hi');
+  });
+});
+
+// ─── decodePayload validation ────────────────────────────────────────────────
+
+describe('decodePayload', () => {
+  it('throws on malformed base64', () => {
+    expect(() => decodePayload('!!!not-base64!!!')).toThrow(/malformed|invalid data/);
+  });
+
+  it('throws on valid base64 that is not JSON', () => {
+    const encoded = btoa('not json').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    expect(() => decodePayload(encoded)).toThrow(/invalid data/);
+  });
+
+  it('throws on payload missing version', () => {
+    const bad = btoa(JSON.stringify({ request: {} })).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    expect(() => decodePayload(bad)).toThrow(/invalid data/);
+  });
+
+  it('throws on payload from a newer version', () => {
+    const payload = { v: SHARE_VERSION + 99, request: createDefaultRequest(), includesSecrets: false };
+    const enc = btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    expect(() => decodePayload(enc)).toThrow(/newer version/);
+  });
+});
+
+// ─── buildShareUrl ───────────────────────────────────────────────────────────
+
+describe('buildShareUrl', () => {
+  it('formats origin + hash correctly', () => {
+    const url = buildShareUrl('https://curlit.app', 'abc123');
+    expect(url).toBe('https://curlit.app/#share=abc123');
+  });
+});
+
+// ─── sharedRequestToTabSeed ──────────────────────────────────────────────────
+
+describe('sharedRequestToTabSeed', () => {
+  it('drops scripts and id from incoming payload', () => {
+    const encoded = encodeRequest(requestWithEverything(), { includeSecrets: true });
+    const payload = decodePayload(encoded);
+    const seed = sharedRequestToTabSeed(payload);
+    // Scripts always stripped on import, even when sender opted in
+    expect(seed.preRequestScript).toBeUndefined();
+    expect(seed.testScript).toBeUndefined();
+    expect(seed.id).toBeUndefined();
+    // Non-secret fields preserved
+    expect(seed.url).toBe('https://api.example.com/users');
+  });
+
+  it('falls back to "Shared Request" when name is empty', () => {
+    const req = createDefaultRequest({ name: '' });
+    const encoded = encodeRequest(req, { includeSecrets: false });
+    const payload = decodePayload(encoded);
+    expect(sharedRequestToTabSeed(payload).name).toBe('Shared Request');
+  });
+});
+
+// ─── readShareFromLocation ───────────────────────────────────────────────────
+
+describe('readShareFromLocation', () => {
+  const originalHash = window.location.hash;
+
+  beforeEach(() => {
+    history.replaceState(null, '', window.location.pathname);
+  });
+
+  afterEach(() => {
+    history.replaceState(null, '', window.location.pathname + originalHash);
+  });
+
+  it('returns null when no share hash is present', () => {
+    expect(readShareFromLocation()).toBeNull();
+  });
+
+  it('decodes a valid share hash and clears it', () => {
+    const req = createDefaultRequest({ url: 'https://shared.com' });
+    const encoded = encodeRequest(req, { includeSecrets: false });
+    history.replaceState(null, '', `${window.location.pathname}#share=${encoded}`);
+
+    const payload = readShareFromLocation();
+    expect(payload).not.toBeNull();
+    expect(payload!.request.url).toBe('https://shared.com');
+    expect(window.location.hash).toBe('');
+  });
+
+  it('throws and clears the hash when the share is malformed', () => {
+    history.replaceState(null, '', `${window.location.pathname}#share=!!!garbage!!!`);
+    expect(() => readShareFromLocation()).toThrow();
+    expect(window.location.hash).toBe('');
+  });
+});

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,0 +1,142 @@
+import type { RequestConfig, FormDataEntry } from '../types';
+
+export const SHARE_VERSION = 1;
+
+export interface SharePayload {
+  v: number;
+  request: RequestConfig;
+  includesSecrets: boolean;
+}
+
+export interface ShareOptions {
+  includeSecrets: boolean;
+}
+
+function base64UrlEncode(str: string): string {
+  const bytes = new TextEncoder().encode(str);
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(b64url: string): string {
+  const pad = '='.repeat((4 - (b64url.length % 4)) % 4);
+  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/') + pad;
+  const binary = atob(b64);
+  const bytes = Uint8Array.from(binary, c => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+/**
+ * Strip everything a share link should never carry by default: auth credentials
+ * and pre-request/test scripts.
+ */
+function stripSecrets(request: RequestConfig): RequestConfig {
+  const cleaned: RequestConfig = { ...request, auth: { type: 'none' } };
+  delete cleaned.preRequestScript;
+  delete cleaned.testScript;
+  return cleaned;
+}
+
+/**
+ * File references are in-memory only and cannot survive a share link. Convert
+ * file entries to empty text entries so the recipient sees the field with a
+ * note to re-attach rather than a dangling reference.
+ */
+function stripFormDataFiles(request: RequestConfig): RequestConfig {
+  if (request.body.type !== 'form-data') return request;
+  const sanitized: FormDataEntry[] = request.body.formData.map(entry => {
+    if (entry.valueType !== 'file') return entry;
+    return {
+      id: entry.id,
+      key: entry.key,
+      value: '',
+      enabled: entry.enabled,
+      description: entry.description,
+      valueType: 'text',
+    };
+  });
+  return {
+    ...request,
+    body: { ...request.body, formData: sanitized },
+  };
+}
+
+export function encodeRequest(request: RequestConfig, options: ShareOptions): string {
+  const withoutFiles = stripFormDataFiles(request);
+  const cleaned = options.includeSecrets ? withoutFiles : stripSecrets(withoutFiles);
+  const payload: SharePayload = {
+    v: SHARE_VERSION,
+    request: cleaned,
+    includesSecrets: options.includeSecrets,
+  };
+  return base64UrlEncode(JSON.stringify(payload));
+}
+
+export function buildShareUrl(origin: string, encoded: string): string {
+  return `${origin}/#share=${encoded}`;
+}
+
+export function decodePayload(encoded: string): SharePayload {
+  let json: string;
+  try {
+    json = base64UrlDecode(encoded);
+  } catch {
+    throw new Error('Share link is malformed');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error('Share link contains invalid data');
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Share link contains invalid data');
+  }
+  const p = parsed as Partial<SharePayload>;
+  if (typeof p.v !== 'number') {
+    throw new Error('Share link contains invalid data');
+  }
+  if (p.v > SHARE_VERSION) {
+    throw new Error(`Share link was created with a newer version (v${p.v}). Update CurlIt to open it.`);
+  }
+  if (!p.request || typeof p.request !== 'object') {
+    throw new Error('Share link contains invalid data');
+  }
+  return p as SharePayload;
+}
+
+/**
+ * Return overrides to pass to addTab when opening a shared request. Always
+ * drop pre-request/test scripts on the import side (belt-and-braces — the
+ * sender should have stripped them, but we defend against hand-crafted links).
+ */
+export function sharedRequestToTabSeed(payload: SharePayload): Partial<RequestConfig> {
+  const { preRequestScript: _pre, testScript: _test, id: _id, ...rest } = payload.request;
+  return { ...rest, name: rest.name || 'Shared Request' };
+}
+
+function clearShareHash(): void {
+  history.replaceState(null, '', window.location.pathname + window.location.search);
+}
+
+/**
+ * Extract a share payload from the current URL hash, or null if no share is present.
+ * On success or failure, clears the hash so a refresh doesn't re-import.
+ */
+export function readShareFromLocation(): SharePayload | null {
+  if (typeof window === 'undefined') return null;
+  const hash = window.location.hash;
+  if (!hash.startsWith('#share=')) return null;
+  const encoded = hash.slice('#share='.length);
+  try {
+    const payload = decodePayload(encoded);
+    clearShareHash();
+    return payload;
+  } catch {
+    clearShareHash();
+    throw new Error('This share link could not be opened');
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a **Share** button in the header that encodes the active request as a base64url payload in the URL fragment (`#share=...`). The fragment stays client-side — never reaches the proxy server or any HTTP logs.
- **Opt-in secrets**: by default, auth credentials and pre-request/test scripts are stripped. A toggle in the modal keeps them, paired with a visible warning about the leak risk (chat logs, browser history, screenshots).
- On the import side, scripts are always stripped as defence against hand-crafted links.
- Form-data file attachments become empty text entries (files can't travel through a URL).
- Hash-decoding runs on both mount (StrictMode-guarded) and `hashchange`, so same-tab navigations work too.
- Size indicator in the modal warns when the link gets long enough to be truncated by chat apps.
- Implements the `v1.3` roadmap item `Shareable request links (encoded in URL)`.

## Test plan
- [x] 17 unit tests in `src/utils/__tests__/share.test.ts`: base64url round-trip, unicode, URL safety, secrets stripped by default, secrets preserved opt-in, form-data file stripping, version gating, malformed payloads, hash-reader with cleanup.
- [x] 2 Playwright e2e tests in `e2e/share.spec.ts`: full generate → navigate → restore round-trip with hash cleanup, and secrets toggle behaviour verifying the encoded payload.
- [x] Full suite: `npm test -- --run` → 384 passed (up from 367).
- [x] Manual smoke: fill a request with bearer auth → Share → copy link → verify decoded payload has no bearer → toggle secrets on → verify bearer is present → open link in same tab → new tab with correct URL, hash cleared.