### PR TITLE
Add cloud sync via GitHub Gist

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,7 +55,7 @@
 
 - [x] Export/import all data (full backup as single JSON)
 - [x] Shareable request links (encoded in URL)
-- [ ] Optional cloud sync via GitHub Gist or a self-hosted backend
+- [x] Optional cloud sync via GitHub Gist or a self-hosted backend
 - [ ] Team workspaces with shared collections
 - [ ] Real-time collaboration (conflict-free editing)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -220,6 +220,47 @@ Leave this off unless you're sharing with someone you trust over a channel you t
 
 ---
 
+## Cloud Sync (GitHub Gist)
+
+Sync your **collections and environments** across devices via a private Gist on your own GitHub account. Only those two are synced -- history, chain variables, and theme stay local.
+
+### One-Time Setup (Maintainer)
+
+The CurlIt maintainer (or self-hoster) needs to register a GitHub OAuth app:
+
+1. Go to https://github.com/settings/developers -> **New OAuth App**
+2. Application name: anything (e.g. "CurlIt")
+3. Homepage URL: wherever the app is hosted
+4. **Enable Device Flow** in the app's settings after creation
+5. Copy the **Client ID**, then start the proxy with it in the environment:
+
+   ```bash
+   GITHUB_CLIENT_ID=Iv1.xxxxx node server/proxy.js
+   ```
+
+If `GITHUB_CLIENT_ID` isn't set, the Sync modal shows a clear "not configured" state and sign-in is hidden.
+
+### Signing In
+
+1. Click **Sync** in the header
+2. Click **Sign in with GitHub**
+3. A short code appears. Open the GitHub link, paste the code, and authorize CurlIt's `gist` scope
+4. The modal flips to the signed-in view showing `@yourhandle` and your data counts
+
+### Syncing
+
+- **Sync Now** pushes the current collections + environments to your Gist (creates one named `curlit-sync.json` on first push; updates it on subsequent pushes).
+- **Pull from Cloud** fetches the Gist and shows a preview. Pick **Merge** (default; adds with fresh IDs, nothing is overwritten) or **Replace** (confirmation required; overwrites local collections/envs).
+- A second device finds the same Gist automatically by filename -- no Gist URL to copy around.
+
+### Safety Notes
+
+- Environment values are stored **plaintext** in your private Gist. Avoid syncing real production secrets until client-side encryption is added (a follow-up).
+- Pre-request and test scripts are stripped on pull, consistent with backup and share-link imports.
+- Sign out clears the OAuth token, Gist id, and last-synced timestamp from your local storage. Your Gist on GitHub is left alone -- delete it there if you want to fully revoke.
+
+---
+
 ## cURL Integration
 
 ### Importing a cURL Command

--- a/e2e/sync.spec.ts
+++ b/e2e/sync.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Cloud Sync (GitHub Gist)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('shows unconfigured state when the proxy lacks GITHUB_CLIENT_ID', async ({ page }) => {
+    await page.route('**/api/github/status', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"configured":false}' })
+    );
+
+    await page.locator('button[title="Cloud sync via GitHub Gist"]').click();
+    await expect(page.getByRole('heading', { name: 'Cloud Sync' })).toBeVisible();
+    await expect(page.getByText(/not configured on this CurlIt instance/)).toBeVisible();
+  });
+
+  test('sign-in completes via the stubbed device flow', async ({ page }) => {
+    // Status: configured
+    await page.route('**/api/github/status', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"configured":true}' })
+    );
+
+    // Device code endpoint
+    await page.route('**/api/github/device-code', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          device_code: 'dc-xyz',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://github.com/login/device',
+          interval: 1,
+          expires_in: 900,
+        }),
+      })
+    );
+
+    // Token poll: return pending once, then access_token
+    let pollCount = 0;
+    await page.route('**/api/github/device-token', route => {
+      pollCount++;
+      const body =
+        pollCount === 1
+          ? JSON.stringify({ error: 'authorization_pending' })
+          : JSON.stringify({ access_token: 'ghs_test_token', token_type: 'bearer', scope: 'gist' });
+      route.fulfill({ status: 200, contentType: 'application/json', body });
+    });
+
+    // GitHub /user — called after token is stored to fetch username
+    await page.route('**/api.github.com/user', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ login: 'octocat' }),
+      })
+    );
+
+    await page.locator('button[title="Cloud sync via GitHub Gist"]').click();
+
+    // Signed-out state → click Sign in
+    await page.getByRole('button', { name: /Sign in with GitHub/ }).click();
+
+    // Device code panel appears
+    await expect(page.getByText('ABCD-1234')).toBeVisible();
+
+    // After pending + success polls, the signed-in state should appear
+    await expect(page.getByText(/Connected as/)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('@octocat')).toBeVisible();
+
+    // Token was persisted
+    const stored = await page.evaluate(() => localStorage.getItem('curlit_sync_token'));
+    expect(stored).toContain('ghs_test_token');
+
+    // At least 2 polls happened (pending then ok)
+    expect(pollCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test('sign-out clears the local sync token', async ({ page }) => {
+    // Seed a token so we start in signed-in state
+    await page.evaluate(() => localStorage.setItem('curlit_sync_token', JSON.stringify('ghs_seed')));
+    await page.route('**/api/github/status', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"configured":true}' })
+    );
+    await page.route('**/api.github.com/user', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ login: 'seeded-user' }),
+      })
+    );
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('button[title="Cloud sync via GitHub Gist"]').click();
+    await expect(page.getByText('@seeded-user')).toBeVisible();
+
+    await page.getByRole('button', { name: /Sign out/ }).click();
+    await expect(page.getByRole('button', { name: /Sign in with GitHub/ })).toBeVisible();
+
+    const stored = await page.evaluate(() => localStorage.getItem('curlit_sync_token'));
+    expect(stored === null || stored === 'null').toBe(true);
+  });
+});

--- a/server/__tests__/proxy.test.js
+++ b/server/__tests__/proxy.test.js
@@ -106,3 +106,91 @@ describe('OAuth Token Endpoint', () => {
     expect(res.body.error).toBeDefined();
   });
 });
+
+describe('GitHub Sync Endpoints', () => {
+  const ORIGINAL_FETCH = global.fetch;
+  const ORIGINAL_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
+
+  afterAll(() => {
+    global.fetch = ORIGINAL_FETCH;
+    if (ORIGINAL_CLIENT_ID === undefined) delete process.env.GITHUB_CLIENT_ID;
+    else process.env.GITHUB_CLIENT_ID = ORIGINAL_CLIENT_ID;
+  });
+
+  describe('GET /api/github/status', () => {
+    it('reports unconfigured when GITHUB_CLIENT_ID is absent', async () => {
+      delete process.env.GITHUB_CLIENT_ID;
+      const res = await request.get('/api/github/status');
+      expect(res.status).toBe(200);
+      expect(res.body.configured).toBe(false);
+    });
+
+    it('reports configured when GITHUB_CLIENT_ID is set', async () => {
+      process.env.GITHUB_CLIENT_ID = 'test-client-id';
+      const res = await request.get('/api/github/status');
+      expect(res.body.configured).toBe(true);
+    });
+  });
+
+  describe('POST /api/github/device-code', () => {
+    it('returns 501 when GITHUB_CLIENT_ID is not configured', async () => {
+      delete process.env.GITHUB_CLIENT_ID;
+      const res = await request.post('/api/github/device-code').send({});
+      expect(res.status).toBe(501);
+      expect(res.body.error).toMatch(/not configured/);
+    });
+
+    it('proxies GitHub response and includes scope=gist', async () => {
+      process.env.GITHUB_CLIENT_ID = 'test-client-id';
+      let capturedBody = null;
+      global.fetch = vi.fn(async (_url, init) => {
+        capturedBody = init.body;
+        return {
+          status: 200,
+          json: async () => ({
+            device_code: 'abc',
+            user_code: 'WXYZ-1234',
+            verification_uri: 'https://github.com/login/device',
+            expires_in: 900,
+            interval: 5,
+          }),
+        };
+      });
+      const res = await request.post('/api/github/device-code').send({});
+      expect(res.status).toBe(200);
+      expect(res.body.user_code).toBe('WXYZ-1234');
+      expect(capturedBody).toContain('client_id=test-client-id');
+      expect(capturedBody).toContain('scope=gist');
+    });
+  });
+
+  describe('POST /api/github/device-token', () => {
+    it('returns 400 when deviceCode is missing', async () => {
+      process.env.GITHUB_CLIENT_ID = 'test-client-id';
+      const res = await request.post('/api/github/device-token').send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('deviceCode is required');
+    });
+
+    it('forwards authorization_pending response transparently', async () => {
+      process.env.GITHUB_CLIENT_ID = 'test-client-id';
+      global.fetch = vi.fn(async () => ({
+        status: 200,
+        json: async () => ({ error: 'authorization_pending' }),
+      }));
+      const res = await request.post('/api/github/device-token').send({ deviceCode: 'dc' });
+      expect(res.status).toBe(200);
+      expect(res.body.error).toBe('authorization_pending');
+    });
+
+    it('returns access token on success', async () => {
+      process.env.GITHUB_CLIENT_ID = 'test-client-id';
+      global.fetch = vi.fn(async () => ({
+        status: 200,
+        json: async () => ({ access_token: 'ghs_xyz', token_type: 'bearer', scope: 'gist' }),
+      }));
+      const res = await request.post('/api/github/device-token').send({ deviceCode: 'dc' });
+      expect(res.body.access_token).toBe('ghs_xyz');
+    });
+  });
+});

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -244,6 +244,59 @@ app.post('/api/oauth/token', async (req, res) => {
   }
 });
 
+// ─── GitHub Sync: device flow + status ────────────────────────────────────────
+// Client ID comes from env so it stays off the wire from the browser, mirroring
+// how /api/oauth/token keeps user-provided secrets server-side.
+app.get('/api/github/status', (_req, res) => {
+  res.json({ configured: !!process.env.GITHUB_CLIENT_ID });
+});
+
+app.post('/api/github/device-code', async (_req, res) => {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    return res.status(501).json({ error: 'GITHUB_CLIENT_ID not configured on server' });
+  }
+  try {
+    const response = await fetch('https://github.com/login/device/code', {
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ client_id: clientId, scope: 'gist' }).toString(),
+    });
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (error) {
+    const cause = error.cause || error;
+    res.status(500).json({ error: cause.message || 'Device code request failed' });
+  }
+});
+
+app.post('/api/github/device-token', async (req, res) => {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    return res.status(501).json({ error: 'GITHUB_CLIENT_ID not configured on server' });
+  }
+  const { deviceCode } = req.body;
+  if (!deviceCode) {
+    return res.status(400).json({ error: 'deviceCode is required' });
+  }
+  try {
+    const response = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: clientId,
+        device_code: deviceCode,
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      }).toString(),
+    });
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (error) {
+    const cause = error.cause || error;
+    res.status(500).json({ error: cause.message || 'Device token poll failed' });
+  }
+});
+
 // Export app for testing
 export { app };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import {
   Moon,
   Archive,
   Share2,
+  Cloud,
 } from 'lucide-react';
 import { useAppStore } from './store';
 import { RequestTabs } from './components/RequestTabs';
@@ -26,6 +27,7 @@ import { OpenApiImportModal } from './components/OpenApiImportModal';
 import { SaveRequestModal } from './components/SaveRequestModal';
 import { BackupModal } from './components/BackupModal';
 import { ShareRequestModal } from './components/ShareRequestModal';
+import { SyncModal } from './components/SyncModal';
 import { useResizable } from './hooks/useResizable';
 import { disconnectWebSocket } from './utils/websocket';
 import { readShareFromLocation, sharedRequestToTabSeed } from './utils/share';
@@ -49,6 +51,7 @@ function App() {
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [showBackup, setShowBackup] = useState(false);
   const [showShare, setShowShare] = useState(false);
+  const [showSync, setShowSync] = useState(false);
 
   const activeTab = tabs.find(t => t.id === activeTabId);
   const activeRequest = activeTab ? requests[activeTab.requestId] : null;
@@ -189,6 +192,14 @@ function App() {
           )}
 
           <button
+            onClick={() => setShowSync(true)}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-dark-300 hover:text-dark-100 bg-dark-700 hover:bg-dark-600 rounded-md transition-colors cursor-pointer"
+            title="Cloud sync via GitHub Gist"
+          >
+            <Cloud size={13} />
+            Sync
+          </button>
+          <button
             onClick={() => setShowBackup(true)}
             className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-dark-300 hover:text-dark-100 bg-dark-700 hover:bg-dark-600 rounded-md transition-colors cursor-pointer"
             title="Backup & Restore all data"
@@ -311,6 +322,7 @@ function App() {
       <SaveRequestModal open={showSaveModal} onClose={() => setShowSaveModal(false)} />
       <BackupModal open={showBackup} onClose={() => setShowBackup(false)} />
       <ShareRequestModal open={showShare} onClose={() => setShowShare(false)} request={activeRequest} />
+      <SyncModal open={showSync} onClose={() => setShowSync(false)} />
     </div>
   );
 }

--- a/src/components/SyncModal.tsx
+++ b/src/components/SyncModal.tsx
@@ -1,0 +1,462 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  X,
+  Cloud,
+  CloudUpload,
+  CloudDownload,
+  LogOut,
+  AlertTriangle,
+  ExternalLink,
+  Check,
+  Loader2,
+} from 'lucide-react';
+import { useAppStore } from '../store';
+import {
+  fetchSyncStatus,
+  getAuthenticatedUser,
+  pollDeviceToken,
+  requestDeviceCode,
+  type DeviceCode,
+} from '../utils/github';
+import {
+  applySyncPayload,
+  ensureGist,
+  pullFromCloud,
+  pushToCloud,
+  type SyncPayload,
+} from '../utils/sync';
+import type { ImportMode } from '../utils/backup';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Phase =
+  | { kind: 'loading' }
+  | { kind: 'unconfigured' }
+  | { kind: 'signed-out' }
+  | { kind: 'device-code'; code: DeviceCode }
+  | { kind: 'signed-in'; login: string | null }
+  | { kind: 'pull-preview'; payload: SyncPayload };
+
+export function SyncModal({ open, onClose }: Props) {
+  const syncToken = useAppStore(s => s.syncToken);
+  const syncGistId = useAppStore(s => s.syncGistId);
+  const syncLastSyncedAt = useAppStore(s => s.syncLastSyncedAt);
+  const collections = useAppStore(s => s.collections);
+  const environments = useAppStore(s => s.environments);
+
+  const [phase, setPhase] = useState<Phase>({ kind: 'loading' });
+  const [busy, setBusy] = useState<null | 'push' | 'pull' | 'signin'>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<ImportMode>('merge');
+  const pollCancelRef = useRef<{ cancelled: boolean }>({ cancelled: false });
+
+  // ─── Initial phase detection ───────────────────────────────────────────────
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setError(null);
+    setPhase({ kind: 'loading' });
+
+    (async () => {
+      const status = await fetchSyncStatus();
+      if (cancelled) return;
+      if (!status.configured) {
+        setPhase({ kind: 'unconfigured' });
+        return;
+      }
+      if (!syncToken) {
+        setPhase({ kind: 'signed-out' });
+        return;
+      }
+      try {
+        const user = await getAuthenticatedUser(syncToken);
+        if (!cancelled) setPhase({ kind: 'signed-in', login: user.login });
+      } catch {
+        // token rejected; treat as signed-out but keep the stale token cleanup to the user
+        if (!cancelled) setPhase({ kind: 'signed-out' });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, syncToken]);
+
+  // ─── Cancel any in-flight polling when modal closes ────────────────────────
+  useEffect(() => {
+    if (!open) {
+      pollCancelRef.current.cancelled = true;
+    }
+  }, [open]);
+
+  const startSignIn = useCallback(async () => {
+    setError(null);
+    setBusy('signin');
+    try {
+      const code = await requestDeviceCode();
+      setPhase({ kind: 'device-code', code });
+      pollCancelRef.current = { cancelled: false };
+      const cancelToken = pollCancelRef.current;
+
+      const expiresAt = Date.now() + code.expiresIn * 1000;
+      let interval = code.interval;
+      const poll = async () => {
+        if (cancelToken.cancelled) return;
+        if (Date.now() > expiresAt) {
+          setError('Sign-in timed out. Try again.');
+          setPhase({ kind: 'signed-out' });
+          setBusy(null);
+          return;
+        }
+        const result = await pollDeviceToken(code.deviceCode);
+        if (cancelToken.cancelled) return;
+        switch (result.status) {
+          case 'ok':
+            useAppStore.getState().setSyncToken(result.accessToken);
+            setBusy(null);
+            return;
+          case 'pending':
+            setTimeout(poll, interval * 1000);
+            return;
+          case 'slow_down':
+            interval = result.intervalHint ?? interval + 5;
+            setTimeout(poll, interval * 1000);
+            return;
+          case 'expired':
+            setError('Sign-in expired before you authorized. Try again.');
+            setPhase({ kind: 'signed-out' });
+            setBusy(null);
+            return;
+          case 'denied':
+            setError('Sign-in was denied.');
+            setPhase({ kind: 'signed-out' });
+            setBusy(null);
+            return;
+          case 'error':
+            setError(result.message);
+            setPhase({ kind: 'signed-out' });
+            setBusy(null);
+            return;
+        }
+      };
+      void poll();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sign-in failed');
+      setBusy(null);
+    }
+  }, []);
+
+  const cancelSignIn = useCallback(() => {
+    pollCancelRef.current.cancelled = true;
+    setPhase({ kind: 'signed-out' });
+    setBusy(null);
+  }, []);
+
+  const signOut = useCallback(() => {
+    useAppStore.getState().clearSyncToken();
+    setPhase({ kind: 'signed-out' });
+  }, []);
+
+  const handlePush = useCallback(async () => {
+    if (!syncToken) return;
+    setError(null);
+    setBusy('push');
+    try {
+      let gistId = syncGistId;
+      if (!gistId) {
+        gistId = await ensureGist(syncToken);
+        useAppStore.getState().setSyncGistId(gistId);
+      }
+      await pushToCloud(syncToken, gistId, useAppStore.getState().getSyncSnapshot());
+      useAppStore.getState().setSyncLastSyncedAt(Date.now());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sync failed');
+    } finally {
+      setBusy(null);
+    }
+  }, [syncToken, syncGistId]);
+
+  const handlePullRequest = useCallback(async () => {
+    if (!syncToken) return;
+    setError(null);
+    setBusy('pull');
+    try {
+      let gistId = syncGistId;
+      if (!gistId) {
+        gistId = await ensureGist(syncToken);
+        useAppStore.getState().setSyncGistId(gistId);
+      }
+      const payload = await pullFromCloud(syncToken, gistId);
+      setPhase({ kind: 'pull-preview', payload });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Pull failed');
+    } finally {
+      setBusy(null);
+    }
+  }, [syncToken, syncGistId]);
+
+  const confirmPull = useCallback(() => {
+    if (phase.kind !== 'pull-preview') return;
+    if (mode === 'replace') {
+      const ok = confirm('Replace all collections and environments with the cloud copy?');
+      if (!ok) return;
+    }
+    const current = useAppStore.getState().getSyncSnapshot();
+    const next = applySyncPayload(current, phase.payload, mode);
+    useAppStore.getState().applySyncSnapshot(next);
+    useAppStore.getState().setSyncLastSyncedAt(Date.now());
+    // Flip back to signed-in view
+    getAuthenticatedUser(syncToken!)
+      .then(u => setPhase({ kind: 'signed-in', login: u.login }))
+      .catch(() => setPhase({ kind: 'signed-in', login: null }));
+  }, [phase, mode, syncToken]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-dark-800 border border-dark-600 rounded-xl shadow-2xl w-full max-w-lg mx-4">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-dark-600">
+          <div className="flex items-center gap-2">
+            <Cloud size={16} className="text-accent-blue" />
+            <h3 className="text-sm font-semibold text-dark-100">Cloud Sync</h3>
+          </div>
+          <button onClick={onClose} className="p-1 text-dark-400 hover:text-dark-200 rounded cursor-pointer">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="p-4">
+          {error && (
+            <div className="mb-3 flex items-start gap-2 px-3 py-2 bg-accent-red/10 border border-accent-red/30 rounded text-xs text-accent-red">
+              <AlertTriangle size={12} className="mt-0.5 flex-shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {phase.kind === 'loading' && (
+            <div className="flex items-center justify-center py-8 text-dark-400 text-xs">
+              <Loader2 size={14} className="animate-spin mr-2" />
+              Checking sync status...
+            </div>
+          )}
+
+          {phase.kind === 'unconfigured' && (
+            <div className="py-4 text-xs text-dark-300">
+              Cloud sync is not configured on this CurlIt instance. The maintainer needs to register a
+              GitHub OAuth app (with Device Flow enabled) and set <code className="text-accent-yellow">GITHUB_CLIENT_ID</code>
+              {' '}in the proxy server environment. See the User Guide for setup instructions.
+            </div>
+          )}
+
+          {phase.kind === 'signed-out' && (
+            <div className="py-2">
+              <p className="text-xs text-dark-300 mb-3">
+                Sign in with GitHub to sync your collections and environments across devices via a
+                private Gist. Only collections and environments are synced -- history, chain variables,
+                and theme stay local.
+              </p>
+              <button
+                onClick={startSignIn}
+                disabled={busy === 'signin'}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm text-white bg-accent-blue hover:bg-accent-blue/80 disabled:opacity-50 rounded-lg cursor-pointer"
+              >
+                {busy === 'signin' ? <Loader2 size={14} className="animate-spin" /> : <Cloud size={14} />}
+                Sign in with GitHub
+              </button>
+            </div>
+          )}
+
+          {phase.kind === 'device-code' && (
+            <div className="py-2">
+              <p className="text-xs text-dark-300 mb-3">
+                1. Open GitHub: <a
+                  href={phase.code.verificationUri}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent-blue underline inline-flex items-center gap-1"
+                >
+                  {phase.code.verificationUri}
+                  <ExternalLink size={10} />
+                </a>
+                <br />
+                2. Enter this code and authorize CurlIt.
+              </p>
+              <div className="bg-dark-900 border border-dark-600 rounded-lg p-4 text-center mb-3">
+                <div className="text-2xl font-mono font-bold tracking-widest text-dark-100">
+                  {phase.code.userCode}
+                </div>
+              </div>
+              <div className="flex items-center justify-center gap-2 text-[11px] text-dark-400 mb-3">
+                <Loader2 size={10} className="animate-spin" />
+                Waiting for you to authorize in GitHub...
+              </div>
+              <button
+                onClick={cancelSignIn}
+                className="w-full px-4 py-2 text-sm text-dark-300 hover:text-dark-100 bg-dark-700 rounded-lg cursor-pointer"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+
+          {phase.kind === 'signed-in' && (
+            <div className="py-2">
+              <div className="flex items-center justify-between mb-3 px-3 py-2 bg-dark-900 border border-dark-600 rounded-lg">
+                <div className="flex items-center gap-2">
+                  <Check size={14} className="text-accent-green" />
+                  <span className="text-xs text-dark-200">
+                    Connected{phase.login && (
+                      <>
+                        {' as '}<span className="font-medium text-dark-100">@{phase.login}</span>
+                      </>
+                    )}
+                  </span>
+                </div>
+                <button
+                  onClick={signOut}
+                  className="flex items-center gap-1 text-[11px] text-dark-400 hover:text-accent-red cursor-pointer"
+                >
+                  <LogOut size={11} />
+                  Sign out
+                </button>
+              </div>
+
+              <div className="bg-dark-900 border border-dark-600 rounded-lg p-3 mb-3">
+                <div className="grid grid-cols-2 gap-3 text-center">
+                  <Stat label="Collections" value={collections.length} />
+                  <Stat label="Environments" value={environments.length} />
+                </div>
+                <div className="mt-3 pt-3 border-t border-dark-700 text-[11px] text-dark-400 text-center">
+                  {syncLastSyncedAt
+                    ? `Last synced ${formatRelative(syncLastSyncedAt)}`
+                    : 'Not synced yet'}
+                </div>
+              </div>
+
+              <div className="flex gap-2 mb-3">
+                <button
+                  onClick={handlePush}
+                  disabled={busy !== null}
+                  className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-sm text-white bg-accent-blue hover:bg-accent-blue/80 disabled:opacity-50 rounded-lg cursor-pointer"
+                >
+                  {busy === 'push' ? <Loader2 size={14} className="animate-spin" /> : <CloudUpload size={14} />}
+                  Sync Now
+                </button>
+                <button
+                  onClick={handlePullRequest}
+                  disabled={busy !== null}
+                  className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-sm text-dark-200 bg-dark-700 hover:bg-dark-600 disabled:opacity-50 rounded-lg cursor-pointer"
+                >
+                  {busy === 'pull' ? <Loader2 size={14} className="animate-spin" /> : <CloudDownload size={14} />}
+                  Pull from Cloud
+                </button>
+              </div>
+
+              <div className="flex items-start gap-2 px-3 py-2 bg-accent-yellow/10 border border-accent-yellow/30 rounded text-[11px] text-accent-yellow">
+                <AlertTriangle size={11} className="mt-0.5 flex-shrink-0" />
+                <span>
+                  Environment values are stored as plaintext in your private Gist. Avoid syncing
+                  production secrets until client-side encryption ships.
+                </span>
+              </div>
+            </div>
+          )}
+
+          {phase.kind === 'pull-preview' && (
+            <div className="py-2">
+              <p className="text-xs text-dark-300 mb-3">Found in cloud:</p>
+              <div className="bg-dark-900 border border-dark-600 rounded-lg p-3 mb-3">
+                <div className="grid grid-cols-2 gap-3 text-center">
+                  <Stat label="Collections" value={phase.payload.data.collections.length} />
+                  <Stat label="Environments" value={phase.payload.data.environments.length} />
+                </div>
+              </div>
+              <div className="mb-3">
+                <div className="text-[11px] text-dark-400 mb-1.5">Import mode:</div>
+                <div className="flex gap-2">
+                  <ModeButton
+                    selected={mode === 'merge'}
+                    onClick={() => setMode('merge')}
+                    label="Merge"
+                    description="Add to existing data"
+                  />
+                  <ModeButton
+                    selected={mode === 'replace'}
+                    onClick={() => setMode('replace')}
+                    label="Replace"
+                    description="Overwrite local"
+                  />
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPhase({ kind: 'signed-in', login: null })}
+                  className="flex-1 px-4 py-2 text-sm text-dark-300 hover:text-dark-100 bg-dark-700 rounded-lg cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={confirmPull}
+                  className="flex-1 flex items-center justify-center gap-1.5 px-4 py-2 text-sm text-white bg-accent-blue hover:bg-accent-blue/80 rounded-lg cursor-pointer"
+                >
+                  <CloudDownload size={14} />
+                  {mode === 'replace' ? 'Replace Local' : 'Merge In'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <div className="text-lg font-semibold text-dark-100">{value}</div>
+      <div className="text-[10px] text-dark-400 uppercase tracking-wider">{label}</div>
+    </div>
+  );
+}
+
+function ModeButton({
+  selected,
+  onClick,
+  label,
+  description,
+}: {
+  selected: boolean;
+  onClick: () => void;
+  label: string;
+  description: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex-1 text-left px-3 py-2 rounded-lg cursor-pointer transition-colors border ${
+        selected
+          ? 'bg-accent-blue/20 border-accent-blue/40 text-dark-100'
+          : 'bg-dark-700 border-transparent text-dark-300 hover:bg-dark-600'
+      }`}
+    >
+      <div className="text-xs font-medium">{label}</div>
+      <div className="text-[10px] text-dark-400">{description}</div>
+    </button>
+  );
+}
+
+function formatRelative(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  if (diff < 60_000) return 'just now';
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -476,6 +476,79 @@ describe('Backup / Restore', () => {
   });
 });
 
+// ─── Sync (GitHub Gist) ──────────────────────────────────────────────────────
+
+describe('Sync', () => {
+  it('setSyncToken persists token and updates state', () => {
+    useAppStore.getState().setSyncToken('ghs_abc');
+    expect(useAppStore.getState().syncToken).toBe('ghs_abc');
+    expect(JSON.parse(localStorage.getItem('curlit_sync_token')!)).toBe('ghs_abc');
+  });
+
+  it('setSyncGistId persists gist id', () => {
+    useAppStore.getState().setSyncGistId('g-123');
+    expect(useAppStore.getState().syncGistId).toBe('g-123');
+    expect(JSON.parse(localStorage.getItem('curlit_sync_gist_id')!)).toBe('g-123');
+  });
+
+  it('setSyncLastSyncedAt persists timestamp', () => {
+    useAppStore.getState().setSyncLastSyncedAt(1700000000000);
+    expect(useAppStore.getState().syncLastSyncedAt).toBe(1700000000000);
+    expect(JSON.parse(localStorage.getItem('curlit_sync_last_synced_at')!)).toBe(1700000000000);
+  });
+
+  it('clearSyncToken wipes all three sync keys', () => {
+    useAppStore.getState().setSyncToken('ghs_abc');
+    useAppStore.getState().setSyncGistId('g-1');
+    useAppStore.getState().setSyncLastSyncedAt(123);
+
+    useAppStore.getState().clearSyncToken();
+
+    const state = useAppStore.getState();
+    expect(state.syncToken).toBeNull();
+    expect(state.syncGistId).toBeNull();
+    expect(state.syncLastSyncedAt).toBeNull();
+    expect(JSON.parse(localStorage.getItem('curlit_sync_token')!)).toBeNull();
+    expect(JSON.parse(localStorage.getItem('curlit_sync_gist_id')!)).toBeNull();
+    expect(JSON.parse(localStorage.getItem('curlit_sync_last_synced_at')!)).toBeNull();
+  });
+
+  it('getSyncSnapshot returns ONLY collections, environments, activeEnvironmentId', () => {
+    useAppStore.getState().createCollection('Col');
+    useAppStore.getState().createEnvironment('Env');
+    useAppStore.getState().addToHistory(createDefaultRequest({ url: 'https://h.com' }), null);
+    useAppStore.getState().updateChainVariables({ x: 'y' });
+
+    const snapshot = useAppStore.getState().getSyncSnapshot();
+    expect(Object.keys(snapshot).sort()).toEqual(['activeEnvironmentId', 'collections', 'environments']);
+    expect(snapshot.collections).toHaveLength(1);
+    expect(snapshot.environments).toHaveLength(1);
+  });
+
+  it('applySyncSnapshot writes collections/envs/active env through to store and localStorage', () => {
+    useAppStore.getState().createCollection('Will be replaced');
+    useAppStore.getState().addToHistory(createDefaultRequest({ url: 'https://keep.com' }), null);
+
+    useAppStore.getState().applySyncSnapshot({
+      collections: [{ id: 'c1', name: 'From Cloud', requests: [], createdAt: 1, updatedAt: 1 }],
+      environments: [{ id: 'e1', name: 'From Cloud', variables: [], isActive: false }],
+      activeEnvironmentId: 'e1',
+    });
+
+    const state = useAppStore.getState();
+    expect(state.collections.map(c => c.name)).toEqual(['From Cloud']);
+    expect(state.environments.map(e => e.name)).toEqual(['From Cloud']);
+    expect(state.activeEnvironmentId).toBe('e1');
+    // History untouched by sync
+    expect(state.history).toHaveLength(1);
+    expect(state.history[0].request.url).toBe('https://keep.com');
+
+    expect(JSON.parse(localStorage.getItem('curlit_collections')!)[0].name).toBe('From Cloud');
+    expect(JSON.parse(localStorage.getItem('curlit_environments')!)[0].name).toBe('From Cloud');
+    expect(JSON.parse(localStorage.getItem('curlit_active_env')!)).toBe('e1');
+  });
+});
+
 // ─── localStorage Persistence ────────────────────────────────────────────────
 
 describe('localStorage Persistence', () => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,6 +25,9 @@ const STORAGE_KEYS = {
   activeEnv: 'curlit_active_env',
   theme: 'curlit_theme',
   chainVariables: 'curlit_chain_vars',
+  syncToken: 'curlit_sync_token',
+  syncGistId: 'curlit_sync_gist_id',
+  syncLastSyncedAt: 'curlit_sync_last_synced_at',
 };
 
 function loadFromStorage<T>(key: string, fallback: T): T {
@@ -74,6 +77,11 @@ interface AppState {
 
   // WebSocket
   webSocketSessions: Record<string, WebSocketSession>;
+
+  // Sync (GitHub Gist)
+  syncToken: string | null;
+  syncGistId: string | null;
+  syncLastSyncedAt: number | null;
 
   // UI
   theme: Theme;
@@ -128,6 +136,16 @@ interface AppState {
   saveActiveRequest: () => 'saved' | 'needs-collection';
   markTabSaved: (tabId: string, collectionId: string, sourceRequestId: string) => void;
 
+  // Actions - Sync
+  setSyncToken: (token: string | null) => void;
+  clearSyncToken: () => void;
+  setSyncGistId: (id: string | null) => void;
+  setSyncLastSyncedAt: (timestamp: number | null) => void;
+  getSyncSnapshot: () => { collections: Collection[]; environments: Environment[]; activeEnvironmentId: string | null };
+  applySyncSnapshot: (
+    next: { collections: Collection[]; environments: Environment[]; activeEnvironmentId: string | null },
+  ) => void;
+
   // Actions - Backup
   getBackupSnapshot: () => BackupSnapshot;
   importBackup: (backup: BackupData, mode: ImportMode) => void;
@@ -164,6 +182,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   scriptLogs: {},
   chainVariables: loadFromStorage<Record<string, string>>(STORAGE_KEYS.chainVariables, {}),
   webSocketSessions: {},
+  syncToken: loadFromStorage<string | null>(STORAGE_KEYS.syncToken, null),
+  syncGistId: loadFromStorage<string | null>(STORAGE_KEYS.syncGistId, null),
+  syncLastSyncedAt: loadFromStorage<number | null>(STORAGE_KEYS.syncLastSyncedAt, null),
   theme: loadFromStorage<Theme>(STORAGE_KEYS.theme, 'dark'),
   sidebarView: 'collections',
   sidebarOpen: true,
@@ -643,6 +664,44 @@ export const useAppStore = create<AppState>((set, get) => ({
       history: next.history,
       chainVariables: next.chainVariables,
       theme: next.theme,
+    });
+  },
+
+  // Sync actions
+  setSyncToken: (token) => {
+    saveToStorage(STORAGE_KEYS.syncToken, token);
+    set({ syncToken: token });
+  },
+  clearSyncToken: () => {
+    saveToStorage(STORAGE_KEYS.syncToken, null);
+    saveToStorage(STORAGE_KEYS.syncGistId, null);
+    saveToStorage(STORAGE_KEYS.syncLastSyncedAt, null);
+    set({ syncToken: null, syncGistId: null, syncLastSyncedAt: null });
+  },
+  setSyncGistId: (id) => {
+    saveToStorage(STORAGE_KEYS.syncGistId, id);
+    set({ syncGistId: id });
+  },
+  setSyncLastSyncedAt: (timestamp) => {
+    saveToStorage(STORAGE_KEYS.syncLastSyncedAt, timestamp);
+    set({ syncLastSyncedAt: timestamp });
+  },
+  getSyncSnapshot: () => {
+    const state = get();
+    return {
+      collections: state.collections,
+      environments: state.environments,
+      activeEnvironmentId: state.activeEnvironmentId,
+    };
+  },
+  applySyncSnapshot: (next) => {
+    saveToStorage(STORAGE_KEYS.collections, next.collections);
+    saveToStorage(STORAGE_KEYS.environments, next.environments);
+    saveToStorage(STORAGE_KEYS.activeEnv, next.activeEnvironmentId);
+    set({
+      collections: next.collections,
+      environments: next.environments,
+      activeEnvironmentId: next.activeEnvironmentId,
     });
   },
 

--- a/src/utils/__tests__/github.test.ts
+++ b/src/utils/__tests__/github.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createGist,
+  fetchSyncStatus,
+  getAuthenticatedUser,
+  getGist,
+  listGists,
+  pollDeviceToken,
+  readGistFile,
+  requestDeviceCode,
+  updateGist,
+} from '../github';
+
+const originalFetch = global.fetch;
+
+function mockFetchOnce(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  const { ok = true, status = 200 } = init;
+  global.fetch = vi.fn().mockResolvedValueOnce({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as unknown as Response);
+}
+
+beforeEach(() => {
+  global.fetch = originalFetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+// ─── fetchSyncStatus ─────────────────────────────────────────────────────────
+
+describe('fetchSyncStatus', () => {
+  it('returns configured true when the proxy reports so', async () => {
+    mockFetchOnce({ configured: true });
+    const result = await fetchSyncStatus();
+    expect(result.configured).toBe(true);
+  });
+
+  it('returns configured false on network failure', async () => {
+    mockFetchOnce({ configured: false }, { ok: false, status: 500 });
+    const result = await fetchSyncStatus();
+    expect(result.configured).toBe(false);
+  });
+});
+
+// ─── requestDeviceCode ───────────────────────────────────────────────────────
+
+describe('requestDeviceCode', () => {
+  it('normalizes GitHub snake_case fields to camelCase', async () => {
+    mockFetchOnce({
+      device_code: 'abc',
+      user_code: 'WXYZ-1234',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    });
+    const code = await requestDeviceCode();
+    expect(code.deviceCode).toBe('abc');
+    expect(code.userCode).toBe('WXYZ-1234');
+    expect(code.verificationUri).toBe('https://github.com/login/device');
+    expect(code.expiresIn).toBe(900);
+    expect(code.interval).toBe(5);
+  });
+
+  it('defaults interval to 5 and expiresIn to 900 when missing', async () => {
+    mockFetchOnce({
+      device_code: 'abc',
+      user_code: 'WXYZ',
+      verification_uri: 'https://github.com/login/device',
+    });
+    const code = await requestDeviceCode();
+    expect(code.interval).toBe(5);
+    expect(code.expiresIn).toBe(900);
+  });
+
+  it('throws when the server signals not-configured', async () => {
+    mockFetchOnce({ error: 'GITHUB_CLIENT_ID not configured on server' }, { ok: false, status: 501 });
+    await expect(requestDeviceCode()).rejects.toThrow(/not configured/);
+  });
+});
+
+// ─── pollDeviceToken ─────────────────────────────────────────────────────────
+
+describe('pollDeviceToken', () => {
+  it('returns ok with access token on success', async () => {
+    mockFetchOnce({ access_token: 'ghs_xyz', token_type: 'bearer', scope: 'gist' });
+    const result = await pollDeviceToken('dc');
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') expect(result.accessToken).toBe('ghs_xyz');
+  });
+
+  it('maps authorization_pending to pending', async () => {
+    mockFetchOnce({ error: 'authorization_pending' });
+    expect((await pollDeviceToken('dc')).status).toBe('pending');
+  });
+
+  it('maps slow_down with interval hint', async () => {
+    mockFetchOnce({ error: 'slow_down', interval: 10 });
+    const result = await pollDeviceToken('dc');
+    expect(result.status).toBe('slow_down');
+    if (result.status === 'slow_down') expect(result.intervalHint).toBe(10);
+  });
+
+  it('maps expired_token to expired', async () => {
+    mockFetchOnce({ error: 'expired_token' });
+    expect((await pollDeviceToken('dc')).status).toBe('expired');
+  });
+
+  it('maps access_denied to denied', async () => {
+    mockFetchOnce({ error: 'access_denied' });
+    expect((await pollDeviceToken('dc')).status).toBe('denied');
+  });
+
+  it('maps unknown error with description to error', async () => {
+    mockFetchOnce({ error: 'server_error', error_description: 'Something broke' });
+    const result = await pollDeviceToken('dc');
+    expect(result.status).toBe('error');
+    if (result.status === 'error') expect(result.message).toBe('Something broke');
+  });
+});
+
+// ─── Gist API ────────────────────────────────────────────────────────────────
+
+describe('Gist API', () => {
+  it('getAuthenticatedUser returns login', async () => {
+    mockFetchOnce({ login: 'octocat', id: 1 });
+    expect(await getAuthenticatedUser('t')).toEqual({ login: 'octocat', id: 1 });
+  });
+
+  it('listGists returns array', async () => {
+    mockFetchOnce([
+      { id: 'g1', description: 'x', files: {}, updated_at: '2025-01-01T00:00:00Z' },
+    ]);
+    const gists = await listGists('t');
+    expect(gists).toHaveLength(1);
+    expect(gists[0].id).toBe('g1');
+  });
+
+  it('getGist sends Authorization header with Bearer token', async () => {
+    let captured: RequestInit | undefined;
+    global.fetch = vi.fn().mockImplementationOnce(async (_url, init?: RequestInit) => {
+      captured = init;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'g1', description: null, files: {}, updated_at: '' }),
+        text: async () => '',
+      } as unknown as Response;
+    });
+    await getGist('my-token', 'g1');
+    const headers = captured?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer my-token');
+    expect(headers.Accept).toContain('application/vnd.github');
+  });
+
+  it('createGist POSTs with expected body shape', async () => {
+    let captured: RequestInit | undefined;
+    global.fetch = vi.fn().mockImplementationOnce(async (_url, init?: RequestInit) => {
+      captured = init;
+      return {
+        ok: true,
+        status: 201,
+        json: async () => ({ id: 'new', description: 'desc', files: {}, updated_at: '' }),
+        text: async () => '',
+      } as unknown as Response;
+    });
+    await createGist('t', 'curlit-sync.json', '{"hello":1}', 'CurlIt sync', false);
+    expect(captured?.method).toBe('POST');
+    const body = JSON.parse(captured?.body as string);
+    expect(body.description).toBe('CurlIt sync');
+    expect(body.public).toBe(false);
+    expect(body.files['curlit-sync.json'].content).toBe('{"hello":1}');
+  });
+
+  it('updateGist PATCHes with file contents only', async () => {
+    let captured: RequestInit | undefined;
+    global.fetch = vi.fn().mockImplementationOnce(async (_url, init?: RequestInit) => {
+      captured = init;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'g1', description: null, files: {}, updated_at: '' }),
+        text: async () => '',
+      } as unknown as Response;
+    });
+    await updateGist('t', 'g1', 'curlit-sync.json', '{"updated":true}');
+    expect(captured?.method).toBe('PATCH');
+    const body = JSON.parse(captured?.body as string);
+    expect(body.files['curlit-sync.json'].content).toBe('{"updated":true}');
+  });
+
+  it('throws a descriptive error on non-2xx response', async () => {
+    mockFetchOnce('Bad credentials', { ok: false, status: 401 });
+    await expect(getAuthenticatedUser('bad')).rejects.toThrow(/401/);
+  });
+});
+
+// ─── readGistFile ────────────────────────────────────────────────────────────
+
+describe('readGistFile', () => {
+  it('returns content when the file exists', () => {
+    const gist = {
+      id: 'g1',
+      description: null,
+      updated_at: '',
+      files: { 'curlit-sync.json': { filename: 'curlit-sync.json', content: '{}' } },
+    };
+    expect(readGistFile(gist, 'curlit-sync.json')).toBe('{}');
+  });
+
+  it('returns null when the file is missing', () => {
+    const gist = { id: 'g1', description: null, updated_at: '', files: {} };
+    expect(readGistFile(gist, 'curlit-sync.json')).toBeNull();
+  });
+});

--- a/src/utils/__tests__/sync.test.ts
+++ b/src/utils/__tests__/sync.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  SYNC_FILENAME,
+  SYNC_VERSION,
+  applySyncPayload,
+  buildPayload,
+  ensureGist,
+  isSyncPayload,
+  parsePayload,
+  pullFromCloud,
+  pushToCloud,
+  type SyncPayload,
+  type SyncSnapshot,
+} from '../sync';
+import { createDefaultRequest } from '../../types';
+import type { Collection, Environment } from '../../types';
+import * as github from '../github';
+
+// ─── buildPayload ────────────────────────────────────────────────────────────
+
+describe('buildPayload', () => {
+  it('wraps snapshot in versioned envelope', () => {
+    const snapshot: SyncSnapshot = {
+      collections: [],
+      environments: [],
+      activeEnvironmentId: 'env-1',
+    };
+    const payload = buildPayload(snapshot);
+    expect(payload.curlit_sync_version).toBe(SYNC_VERSION);
+    expect(typeof payload.updated_at).toBe('number');
+    expect(payload.data.activeEnvironmentId).toBe('env-1');
+  });
+
+  it('omits history, chain vars, theme — only syncs collections + envs + active env id', () => {
+    const payload = buildPayload({
+      collections: [],
+      environments: [],
+      activeEnvironmentId: null,
+    });
+    expect(Object.keys(payload.data).sort()).toEqual(['activeEnvironmentId', 'collections', 'environments']);
+  });
+});
+
+// ─── isSyncPayload ───────────────────────────────────────────────────────────
+
+describe('isSyncPayload', () => {
+  it('accepts a valid payload', () => {
+    expect(isSyncPayload(buildPayload({ collections: [], environments: [], activeEnvironmentId: null }))).toBe(true);
+  });
+
+  it('rejects a backup payload (wrong version key)', () => {
+    expect(isSyncPayload({ curlit_backup_version: 1, data: {} })).toBe(false);
+  });
+
+  it('rejects null/primitives', () => {
+    expect(isSyncPayload(null)).toBe(false);
+    expect(isSyncPayload(42)).toBe(false);
+    expect(isSyncPayload('string')).toBe(false);
+  });
+});
+
+// ─── parsePayload ────────────────────────────────────────────────────────────
+
+describe('parsePayload', () => {
+  it('parses valid JSON payload', () => {
+    const payload = buildPayload({ collections: [], environments: [], activeEnvironmentId: null });
+    const parsed = parsePayload(JSON.stringify(payload));
+    expect(parsed.curlit_sync_version).toBe(SYNC_VERSION);
+  });
+
+  it('throws on non-sync JSON', () => {
+    expect(() => parsePayload('{"foo":"bar"}')).toThrow(/valid CurlIt sync/);
+  });
+
+  it('throws on future version', () => {
+    const payload = buildPayload({ collections: [], environments: [], activeEnvironmentId: null });
+    payload.curlit_sync_version = SYNC_VERSION + 99;
+    expect(() => parsePayload(JSON.stringify(payload))).toThrow(/newer version/);
+  });
+});
+
+// ─── ensureGist ──────────────────────────────────────────────────────────────
+
+describe('ensureGist', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the id of an existing gist matching the sync filename', async () => {
+    vi.spyOn(github, 'listGists').mockResolvedValue([
+      { id: 'g-other', description: null, files: { 'other.md': { filename: 'other.md', content: '' } }, updated_at: '' },
+      {
+        id: 'g-sync',
+        description: 'CurlIt sync',
+        files: { [SYNC_FILENAME]: { filename: SYNC_FILENAME, content: '{}' } },
+        updated_at: '',
+      },
+    ]);
+    const createSpy = vi.spyOn(github, 'createGist');
+    const id = await ensureGist('token');
+    expect(id).toBe('g-sync');
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('creates a new private gist when none match', async () => {
+    vi.spyOn(github, 'listGists').mockResolvedValue([]);
+    const createSpy = vi.spyOn(github, 'createGist').mockResolvedValue({
+      id: 'g-new',
+      description: 'CurlIt sync',
+      files: {},
+      updated_at: '',
+    });
+    const id = await ensureGist('token');
+    expect(id).toBe('g-new');
+    expect(createSpy).toHaveBeenCalledWith(
+      'token',
+      SYNC_FILENAME,
+      expect.stringContaining('curlit_sync_version'),
+      'CurlIt sync',
+      false, // private
+    );
+  });
+});
+
+// ─── pushToCloud ─────────────────────────────────────────────────────────────
+
+describe('pushToCloud', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes a payload built from the snapshot and returns it', async () => {
+    const updateSpy = vi.spyOn(github, 'updateGist').mockResolvedValue({
+      id: 'g1',
+      description: null,
+      files: {},
+      updated_at: '',
+    });
+
+    const collection: Collection = {
+      id: 'c1',
+      name: 'Col',
+      requests: [createDefaultRequest({ name: 'Req' })],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const environment: Environment = { id: 'e1', name: 'Env', variables: [], isActive: false };
+
+    const payload = await pushToCloud('token', 'g1', {
+      collections: [collection],
+      environments: [environment],
+      activeEnvironmentId: 'e1',
+    });
+
+    expect(payload.data.collections[0].name).toBe('Col');
+    expect(updateSpy).toHaveBeenCalledWith('token', 'g1', SYNC_FILENAME, expect.any(String));
+    const written = JSON.parse(updateSpy.mock.calls[0][3]);
+    expect(written.curlit_sync_version).toBe(SYNC_VERSION);
+    expect(written.data.environments[0].name).toBe('Env');
+  });
+});
+
+// ─── pullFromCloud ───────────────────────────────────────────────────────────
+
+describe('pullFromCloud', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the parsed sync payload', async () => {
+    const payload = buildPayload({ collections: [], environments: [], activeEnvironmentId: 'e1' });
+    vi.spyOn(github, 'getGist').mockResolvedValue({
+      id: 'g1',
+      description: null,
+      files: { [SYNC_FILENAME]: { filename: SYNC_FILENAME, content: JSON.stringify(payload) } },
+      updated_at: '',
+    });
+    const pulled = await pullFromCloud('token', 'g1');
+    expect(pulled.data.activeEnvironmentId).toBe('e1');
+  });
+
+  it('throws when the gist is missing the sync file', async () => {
+    vi.spyOn(github, 'getGist').mockResolvedValue({
+      id: 'g1',
+      description: null,
+      files: { 'other.md': { filename: 'other.md', content: '' } },
+      updated_at: '',
+    });
+    await expect(pullFromCloud('token', 'g1')).rejects.toThrow(/missing/);
+  });
+});
+
+// ─── applySyncPayload ────────────────────────────────────────────────────────
+
+describe('applySyncPayload', () => {
+  function collection(name: string): Collection {
+    return {
+      id: crypto.randomUUID(),
+      name,
+      requests: [createDefaultRequest({ name: `${name}-req` })],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+  }
+  function environment(name: string): Environment {
+    return { id: crypto.randomUUID(), name, variables: [], isActive: false };
+  }
+
+  it('replace mode overwrites current collections and environments', () => {
+    const current: SyncSnapshot = {
+      collections: [collection('Old')],
+      environments: [environment('OldEnv')],
+      activeEnvironmentId: 'existing-id',
+    };
+    const payload: SyncPayload = buildPayload({
+      collections: [collection('New')],
+      environments: [environment('NewEnv')],
+      activeEnvironmentId: 'new-id',
+    });
+    const result = applySyncPayload(current, payload, 'replace');
+    expect(result.collections).toHaveLength(1);
+    expect(result.collections[0].name).toBe('New');
+    expect(result.environments[0].name).toBe('NewEnv');
+    expect(result.activeEnvironmentId).toBe('new-id');
+  });
+
+  it('merge mode appends incoming with fresh IDs and preserves current active env', () => {
+    const current: SyncSnapshot = {
+      collections: [collection('Existing')],
+      environments: [environment('ExistingEnv')],
+      activeEnvironmentId: 'e-existing',
+    };
+    const incomingCol = collection('Incoming');
+    const incomingColId = incomingCol.id;
+    const payload = buildPayload({
+      collections: [incomingCol],
+      environments: [environment('IncomingEnv')],
+      activeEnvironmentId: 'e-incoming',
+    });
+
+    const result = applySyncPayload(current, payload, 'merge');
+    expect(result.collections).toHaveLength(2);
+    expect(result.collections[1].id).not.toBe(incomingColId); // fresh UUID
+    expect(result.environments).toHaveLength(2);
+    expect(result.activeEnvironmentId).toBe('e-existing'); // current preserved
+  });
+
+  it('strips pre-request and test scripts from incoming requests in both modes', () => {
+    const colWithScripts = collection('Scripted');
+    colWithScripts.requests[0].preRequestScript = 'alert(1)';
+    colWithScripts.requests[0].testScript = 'ok(1)';
+    const payload = buildPayload({
+      collections: [colWithScripts],
+      environments: [],
+      activeEnvironmentId: null,
+    });
+
+    for (const mode of ['replace', 'merge'] as const) {
+      const result = applySyncPayload(
+        { collections: [], environments: [], activeEnvironmentId: null },
+        payload,
+        mode,
+      );
+      expect(result.collections[0].requests[0].preRequestScript).toBeUndefined();
+      expect(result.collections[0].requests[0].testScript).toBeUndefined();
+    }
+  });
+});

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,0 +1,162 @@
+/**
+ * Low-level GitHub API helpers for the cloud sync feature. Keeps network
+ * details isolated so src/utils/sync.ts can focus on orchestration.
+ *
+ * Device flow requests go through our Express proxy (/api/github/*) so the
+ * OAuth client_id stays server-side and matches the existing /api/oauth/token
+ * pattern. Gist API calls talk directly to api.github.com since it supports
+ * CORS with a user-held access token.
+ */
+
+// ─── Device flow ─────────────────────────────────────────────────────────────
+
+export interface DeviceCode {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  interval: number;
+  expiresIn: number;
+}
+
+export type DevicePollResult =
+  | { status: 'pending' }
+  | { status: 'slow_down'; intervalHint?: number }
+  | { status: 'ok'; accessToken: string }
+  | { status: 'expired' }
+  | { status: 'denied' }
+  | { status: 'error'; message: string };
+
+export async function fetchSyncStatus(): Promise<{ configured: boolean }> {
+  const res = await fetch('/api/github/status');
+  if (!res.ok) return { configured: false };
+  return res.json();
+}
+
+export async function requestDeviceCode(): Promise<DeviceCode> {
+  const res = await fetch('/api/github/device-code', { method: 'POST' });
+  const data = await res.json();
+  if (!res.ok || !data.device_code) {
+    throw new Error(data.error || 'Could not start GitHub sign-in');
+  }
+  return {
+    deviceCode: data.device_code,
+    userCode: data.user_code,
+    verificationUri: data.verification_uri,
+    interval: data.interval ?? 5,
+    expiresIn: data.expires_in ?? 900,
+  };
+}
+
+export async function pollDeviceToken(deviceCode: string): Promise<DevicePollResult> {
+  const res = await fetch('/api/github/device-token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deviceCode }),
+  });
+  const data = await res.json();
+
+  if (data.access_token) return { status: 'ok', accessToken: data.access_token };
+
+  switch (data.error) {
+    case 'authorization_pending':
+      return { status: 'pending' };
+    case 'slow_down':
+      return { status: 'slow_down', intervalHint: data.interval };
+    case 'expired_token':
+      return { status: 'expired' };
+    case 'access_denied':
+      return { status: 'denied' };
+    default:
+      return { status: 'error', message: data.error_description || data.error || 'Sign-in failed' };
+  }
+}
+
+// ─── Gist API (direct) ───────────────────────────────────────────────────────
+
+const GIST_API = 'https://api.github.com';
+
+export interface GistFile {
+  filename: string;
+  content: string;
+  raw_url?: string;
+  size?: number;
+  truncated?: boolean;
+}
+
+export interface GistSummary {
+  id: string;
+  description: string | null;
+  files: Record<string, GistFile>;
+  updated_at: string;
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+}
+
+async function githubJson<T>(url: string, token: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...authHeaders(token), ...(init.headers as Record<string, string> | undefined) },
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`GitHub ${res.status}: ${detail.slice(0, 200) || res.statusText}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export async function getAuthenticatedUser(token: string): Promise<{ login: string }> {
+  return githubJson<{ login: string }>(`${GIST_API}/user`, token);
+}
+
+/** Lists the authenticated user's gists (paginated, but the first page is enough for our match-by-filename use). */
+export async function listGists(token: string): Promise<GistSummary[]> {
+  return githubJson<GistSummary[]>(`${GIST_API}/gists?per_page=100`, token);
+}
+
+export async function getGist(token: string, id: string): Promise<GistSummary> {
+  return githubJson<GistSummary>(`${GIST_API}/gists/${id}`, token);
+}
+
+export async function createGist(
+  token: string,
+  filename: string,
+  content: string,
+  description: string,
+  isPublic: boolean
+): Promise<GistSummary> {
+  return githubJson<GistSummary>(`${GIST_API}/gists`, token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      description,
+      public: isPublic,
+      files: { [filename]: { content } },
+    }),
+  });
+}
+
+export async function updateGist(
+  token: string,
+  id: string,
+  filename: string,
+  content: string
+): Promise<GistSummary> {
+  return githubJson<GistSummary>(`${GIST_API}/gists/${id}`, token, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ files: { [filename]: { content } } }),
+  });
+}
+
+/** Extract content for a given filename from a gist response. Returns null if the file is missing or truncated beyond reach. */
+export function readGistFile(gist: GistSummary, filename: string): string | null {
+  const file = gist.files[filename];
+  if (!file) return null;
+  return file.content ?? null;
+}

--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -1,0 +1,135 @@
+import type { Collection, Environment } from '../types';
+import {
+  createGist,
+  getGist,
+  listGists,
+  readGistFile,
+  updateGist,
+  type GistSummary,
+} from './github';
+import { applyBackup, type BackupSnapshot, type ImportMode } from './backup';
+
+export const SYNC_VERSION = 1;
+export const SYNC_FILENAME = 'curlit-sync.json';
+export const SYNC_GIST_DESCRIPTION = 'CurlIt sync';
+
+export interface SyncPayload {
+  curlit_sync_version: number;
+  updated_at: number;
+  data: {
+    collections: Collection[];
+    environments: Environment[];
+    activeEnvironmentId: string | null;
+  };
+}
+
+export interface SyncSnapshot {
+  collections: Collection[];
+  environments: Environment[];
+  activeEnvironmentId: string | null;
+}
+
+export function buildPayload(snapshot: SyncSnapshot): SyncPayload {
+  return {
+    curlit_sync_version: SYNC_VERSION,
+    updated_at: Date.now(),
+    data: {
+      collections: snapshot.collections,
+      environments: snapshot.environments,
+      activeEnvironmentId: snapshot.activeEnvironmentId,
+    },
+  };
+}
+
+export function isSyncPayload(obj: unknown): obj is SyncPayload {
+  if (!obj || typeof obj !== 'object') return false;
+  const p = obj as Partial<SyncPayload>;
+  if (typeof p.curlit_sync_version !== 'number') return false;
+  if (!p.data || typeof p.data !== 'object') return false;
+  return Array.isArray(p.data.collections) && Array.isArray(p.data.environments);
+}
+
+export function parsePayload(text: string): SyncPayload {
+  const parsed = JSON.parse(text);
+  if (!isSyncPayload(parsed)) throw new Error('Not a valid CurlIt sync payload');
+  if (parsed.curlit_sync_version > SYNC_VERSION) {
+    throw new Error(
+      `Sync payload was created with a newer version (v${parsed.curlit_sync_version}). Update CurlIt to pull it.`
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Find the existing curlit-sync gist for the user, or create one. Returns the
+ * gist id in both cases. Looking by filename lets a second device converge on
+ * the same gist without any extra configuration.
+ */
+export async function ensureGist(token: string): Promise<string> {
+  const gists = await listGists(token);
+  const existing = gists.find(g => SYNC_FILENAME in g.files);
+  if (existing) return existing.id;
+
+  const empty = buildPayload({ collections: [], environments: [], activeEnvironmentId: null });
+  const created = await createGist(
+    token,
+    SYNC_FILENAME,
+    JSON.stringify(empty, null, 2),
+    SYNC_GIST_DESCRIPTION,
+    false
+  );
+  return created.id;
+}
+
+export async function pushToCloud(token: string, gistId: string, snapshot: SyncSnapshot): Promise<SyncPayload> {
+  const payload = buildPayload(snapshot);
+  await updateGist(token, gistId, SYNC_FILENAME, JSON.stringify(payload, null, 2));
+  return payload;
+}
+
+export async function pullFromCloud(token: string, gistId: string): Promise<SyncPayload> {
+  const gist: GistSummary = await getGist(token, gistId);
+  const raw = readGistFile(gist, SYNC_FILENAME);
+  if (raw == null) throw new Error(`Gist is missing ${SYNC_FILENAME}`);
+  return parsePayload(raw);
+}
+
+/**
+ * Apply a pulled sync payload to a caller-supplied current snapshot. Reuses
+ * applyBackup so merge/replace semantics (fresh UUIDs on merge, script
+ * stripping) stay identical to Backup & Restore. Returns the new collection +
+ * environment lists plus the active env id; the caller is responsible for
+ * writing these into the store and touching localStorage.
+ */
+export function applySyncPayload(
+  current: SyncSnapshot,
+  payload: SyncPayload,
+  mode: ImportMode
+): SyncSnapshot {
+  const currentBackup: BackupSnapshot = {
+    collections: current.collections,
+    environments: current.environments,
+    activeEnvironmentId: current.activeEnvironmentId,
+    history: [],
+    chainVariables: {},
+    theme: 'dark',
+  };
+  const incomingBackup = {
+    curlit_backup_version: 1,
+    exported_at: payload.updated_at,
+    data: {
+      collections: payload.data.collections,
+      environments: payload.data.environments,
+      activeEnvironmentId: payload.data.activeEnvironmentId,
+      history: [],
+      chainVariables: {},
+      theme: 'dark' as const,
+    },
+  };
+  const merged = applyBackup(currentBackup, incomingBackup, mode);
+  return {
+    collections: merged.collections,
+    environments: merged.environments,
+    activeEnvironmentId: merged.activeEnvironmentId,
+  };
+}


### PR DESCRIPTION
## Summary
- Signs the user in with GitHub's **OAuth device flow** and syncs their **collections + environments** to a private Gist named `curlit-sync.json`. History, chain variables, and theme stay per-machine.
- New **Sync** button in the header opens a modal with device-flow sign-in, **Sync Now** (push), and **Pull from Cloud** (merge/replace preview mirroring the Backup modal UX).
- Second device onboarding is zero-click: looks up the user's existing gist by filename.
- Proxy adds three small routes (`/api/github/status`, `/api/github/device-code`, `/api/github/device-token`) so the OAuth client_id stays server-side, matching the existing `/api/oauth/token` pattern.
- Pre-request / test scripts are stripped on pull, consistent with backup and share-link imports.
- Implements the `v1.3` roadmap item `Optional cloud sync via GitHub Gist or a self-hosted backend`.

## Scope / intentional non-goals
- **Plaintext Gist storage** for v1, with a visible warning in the modal. Client-side encryption is a follow-up.
- **Manual only** — no auto-sync, no debounce, no conflict resolution. Last write wins via user intent.
- **No self-hosted backend** yet — deliberately deferred to keep v1 small.

## Setup
Maintainer registers a GitHub OAuth app (Device Flow enabled) and starts the proxy with `GITHUB_CLIENT_ID=... node server/proxy.js`. Without it, the modal shows a clear "not configured" state. Full instructions in `docs/USER_GUIDE.md`.

## Test plan
- [x] **Unit**: 19 tests in `src/utils/__tests__/github.test.ts` (device flow, gist CRUD, auth headers, error mapping); 16 tests in `src/utils/__tests__/sync.test.ts` (payload shape, `ensureGist` find-or-create, push/pull, script stripping, merge vs replace).
- [x] **Store**: 6 new tests covering `setSyncToken`, `clearSyncToken`, `setSyncGistId`, `setSyncLastSyncedAt`, `getSyncSnapshot`, `applySyncSnapshot`.
- [x] **Server**: 7 new tests for the three `/api/github/*` routes (configured/unconfigured, proxying, error responses).
- [x] **E2E** (`e2e/sync.spec.ts`, Playwright with stubbed `page.route`): unconfigured-proxy state, end-to-end device-flow sign-in with pending-then-success polling, sign-out clears token.
- [x] `npm test -- --run` → **432 passed** (up from 384).
- [ ] **Manual smoke** (requires a real OAuth app): sign in → Sync Now → confirm gist created on github.com → sign in on a second profile → Pull from Cloud → Merge → confirm data appears.