### PR TITLE
Add collection runner with pass/fail summary

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,7 +61,7 @@
 
 ### v1.4 -- Performance & Testing
 
-- [ ] Collection runner -- execute all requests in a collection sequentially
+- [x] Collection runner -- execute all requests in a collection sequentially
 - [ ] Performance benchmarking -- run a request N times, report avg/p95/p99
 - [ ] Response diffing -- compare two responses side-by-side
 - [ ] Mock server -- define mock responses for endpoints

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -124,6 +124,22 @@ Click any request in a collection to open it in a new tab.
 
 The import auto-detects the format. To import from Postman, export your Postman collection as **Collection v2.1** JSON, then paste it directly into the import textarea.
 
+### Running a Collection
+
+Execute every request in a collection sequentially and see a pass/fail summary -- the shortest path from a hand-authored suite to an automated smoke test.
+
+1. Click **...** on the collection -> **Run collection**
+2. In the runner modal, optionally pick an environment (defaults to the active one), set a per-request delay in ms (0 by default), and toggle **Stop on first failure**
+3. Click **Start Run**. Each request row shows its status (pending -> running -> passed / failed / errored / skipped) and can be expanded after completion to see the response and any test results.
+
+**What counts as a failure:**
+
+- **passed** -- request completed and either had no tests or all tests passed
+- **failed** -- one or more assertions in `testScript` failed (note: a 4xx/5xx status on its own is *not* a failure -- your tests are authoritative)
+- **errored** -- the network call or pre-request script threw before a response could be collected
+
+Chain variables set by `testScript` during the run are visible to later requests in the same run, so setup/teardown chains (login -> call -> cleanup) work naturally. Click **Stop** to abort in-flight -- any remaining requests are marked **skipped**.
+
 ---
 
 ## Environment Variables

--- a/e2e/collection-runner.spec.ts
+++ b/e2e/collection-runner.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Collection Runner', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => localStorage.clear());
+
+    // Seed a collection with two HTTP GETs against a known-good endpoint
+    await page.evaluate(() => {
+      const emptyBody = { type: 'none', raw: '', formData: [], urlencoded: [] };
+      localStorage.setItem(
+        'curlit_collections',
+        JSON.stringify([
+          {
+            id: 'col-run',
+            name: 'Runner Fixture',
+            createdAt: 1,
+            updatedAt: 1,
+            requests: [
+              {
+                id: 'req-a', name: 'Alpha', method: 'GET',
+                url: 'https://httpbin.org/get',
+                params: [], headers: [], body: emptyBody,
+                auth: { type: 'none' },
+              },
+              {
+                id: 'req-b', name: 'Bravo', method: 'GET',
+                url: 'https://httpbin.org/status/200',
+                params: [], headers: [], body: emptyBody,
+                auth: { type: 'none' },
+              },
+            ],
+          },
+        ]),
+      );
+    });
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('runs all requests sequentially and summarises pass/fail', async ({ page }) => {
+    // Open the collection context menu and click Run collection
+    await page.getByText('Runner Fixture').hover();
+    await page.locator('.group:has-text("Runner Fixture") button').filter({ has: page.locator('svg') }).last().click();
+    await page.getByRole('button', { name: 'Run collection' }).click();
+
+    // Modal is open with the collection name
+    await expect(page.getByRole('heading', { name: /Run Collection — Runner Fixture/ })).toBeVisible();
+
+    // Both request rows visible in pending state
+    await expect(page.getByText('Alpha', { exact: true })).toBeVisible();
+    await expect(page.getByText('Bravo', { exact: true })).toBeVisible();
+
+    // Summary shows total of 2 before start
+    await expect(page.locator('text=TOTAL').locator('..').locator('div').first()).toHaveText('2');
+
+    // Start the run
+    await page.getByRole('button', { name: /Start Run/ }).click();
+
+    // Wait for completion (summary appears at bottom of stat card)
+    await expect(page.getByText(/Completed 2\/2 in/)).toBeVisible({ timeout: 30_000 });
+
+    // Summary: both should pass (no test scripts defined)
+    const passedStat = page.locator('text=PASSED').locator('..').locator('div').first();
+    await expect(passedStat).toHaveText('2');
+
+    const erroredStat = page.locator('text=ERRORED').locator('..').locator('div').first();
+    await expect(erroredStat).toHaveText('0');
+
+    // Start Run button becomes "Run Again"
+    await expect(page.getByRole('button', { name: /Run Again/ })).toBeVisible();
+  });
+
+  test('disables Run collection for an empty collection', async ({ page }) => {
+    // Replace the seeded collection with an empty one
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'curlit_collections',
+        JSON.stringify([
+          { id: 'col-empty', name: 'Empty Col', createdAt: 1, updatedAt: 1, requests: [] },
+        ]),
+      );
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await page.getByText('Empty Col').hover();
+    await page.locator('.group:has-text("Empty Col") button').filter({ has: page.locator('svg') }).last().click();
+    const runItem = page.getByRole('button', { name: 'Run collection' });
+    await expect(runItem).toBeDisabled();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { SaveRequestModal } from './components/SaveRequestModal';
 import { BackupModal } from './components/BackupModal';
 import { ShareRequestModal } from './components/ShareRequestModal';
 import { SyncModal } from './components/SyncModal';
+import { CollectionRunnerModal } from './components/CollectionRunnerModal';
 import { useResizable } from './hooks/useResizable';
 import { disconnectWebSocket } from './utils/websocket';
 import { readShareFromLocation, sharedRequestToTabSeed } from './utils/share';
@@ -52,6 +53,7 @@ function App() {
   const [showBackup, setShowBackup] = useState(false);
   const [showShare, setShowShare] = useState(false);
   const [showSync, setShowSync] = useState(false);
+  const [runnerCollectionId, setRunnerCollectionId] = useState<string | null>(null);
 
   const activeTab = tabs.find(t => t.id === activeTabId);
   const activeRequest = activeTab ? requests[activeTab.requestId] : null;
@@ -249,7 +251,7 @@ function App() {
         {sidebarOpen && (
           <>
             <div style={{ width: sidebarWidth }} className="flex-shrink-0 h-full overflow-hidden">
-              <Sidebar />
+              <Sidebar onRunCollection={id => setRunnerCollectionId(id)} />
             </div>
             <div
               onMouseDown={handleSidebarResize}
@@ -323,6 +325,11 @@ function App() {
       <BackupModal open={showBackup} onClose={() => setShowBackup(false)} />
       <ShareRequestModal open={showShare} onClose={() => setShowShare(false)} request={activeRequest} />
       <SyncModal open={showSync} onClose={() => setShowSync(false)} />
+      <CollectionRunnerModal
+        open={runnerCollectionId !== null}
+        onClose={() => setRunnerCollectionId(null)}
+        collection={useAppStore.getState().collections.find(c => c.id === runnerCollectionId) ?? null}
+      />
     </div>
   );
 }

--- a/src/components/CollectionRunnerModal.tsx
+++ b/src/components/CollectionRunnerModal.tsx
@@ -1,0 +1,327 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  X,
+  Play,
+  Square,
+  Check,
+  AlertTriangle,
+  XCircle,
+  MinusCircle,
+  Loader2,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react';
+import { useAppStore } from '../store';
+import { MethodBadge } from './MethodBadge';
+import type { Collection } from '../types';
+import { runCollection, type RunnerEvent, type RunnerSummary } from '../utils/collectionRunner';
+import type { ExecuteResult } from '../utils/requestExecutor';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  collection: Collection | null;
+}
+
+type RowState =
+  | { status: 'pending' }
+  | { status: 'running' }
+  | { status: 'done'; result: ExecuteResult; durationMs: number }
+  | { status: 'skipped'; reason: 'aborted' | 'stop-on-failure' };
+
+type Phase = 'idle' | 'running' | 'finished';
+
+export function CollectionRunnerModal({ open, onClose, collection }: Props) {
+  const environments = useAppStore(s => s.environments);
+  const activeEnvironmentId = useAppStore(s => s.activeEnvironmentId);
+
+  const [envId, setEnvId] = useState<string | null>(activeEnvironmentId);
+  const [stopOnFailure, setStopOnFailure] = useState(false);
+  const [delayMs, setDelayMs] = useState(0);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [rows, setRows] = useState<RowState[]>([]);
+  const [summary, setSummary] = useState<RunnerSummary | null>(null);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Reset when opened for a different collection
+  useEffect(() => {
+    if (!open) return;
+    setEnvId(activeEnvironmentId);
+    setPhase('idle');
+    setRows(collection ? collection.requests.map(() => ({ status: 'pending' })) : []);
+    setSummary(null);
+    setExpanded(new Set());
+  }, [open, collection, activeEnvironmentId]);
+
+  // Abort any in-flight run when the modal closes
+  useEffect(() => {
+    if (!open) abortRef.current?.abort();
+  }, [open]);
+
+  const resolvedEnv = useMemo(() => environments.find(e => e.id === envId) ?? null, [environments, envId]);
+
+  const toggleRow = (i: number) =>
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+
+  const handleStart = async () => {
+    if (!collection || collection.requests.length === 0) return;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setPhase('running');
+    setSummary(null);
+    setRows(collection.requests.map(() => ({ status: 'pending' })));
+
+    const envVars: Record<string, string> = {};
+    resolvedEnv?.variables
+      .filter(v => v.enabled && v.key)
+      .forEach(v => {
+        envVars[v.key] = v.value;
+      });
+
+    await runCollection({
+      requests: collection.requests,
+      variables: envVars,
+      getChainVars: () => useAppStore.getState().chainVariables,
+      onChainVars: updates => useAppStore.getState().updateChainVariables(updates),
+      stopOnFailure,
+      delayMs,
+      signal: controller.signal,
+      onEvent: (event: RunnerEvent) => {
+        if (event.type === 'request-start') {
+          setRows(prev => {
+            const next = [...prev];
+            next[event.index] = { status: 'running' };
+            return next;
+          });
+        } else if (event.type === 'request-complete') {
+          setRows(prev => {
+            const next = [...prev];
+            next[event.index] = { status: 'done', result: event.result, durationMs: event.durationMs };
+            return next;
+          });
+        } else if (event.type === 'request-skipped') {
+          setRows(prev => {
+            const next = [...prev];
+            next[event.index] = { status: 'skipped', reason: event.reason };
+            return next;
+          });
+        } else if (event.type === 'done') {
+          setSummary(event.summary);
+          setPhase('finished');
+        }
+      },
+    });
+  };
+
+  const handleStop = () => {
+    abortRef.current?.abort();
+  };
+
+  if (!open || !collection) return null;
+
+  const total = collection.requests.length;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-dark-800 border border-dark-600 rounded-xl shadow-2xl w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-dark-600">
+          <div className="flex items-center gap-2">
+            <Play size={16} className="text-accent-blue" />
+            <h3 className="text-sm font-semibold text-dark-100">Run Collection — {collection.name}</h3>
+          </div>
+          <button onClick={onClose} className="p-1 text-dark-400 hover:text-dark-200 rounded cursor-pointer">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="p-4 overflow-auto flex-1">
+          {/* Options */}
+          <div className="flex flex-wrap items-end gap-3 mb-4">
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] text-dark-400 uppercase tracking-wider">Environment</span>
+              <select
+                value={envId ?? ''}
+                onChange={e => setEnvId(e.target.value || null)}
+                disabled={phase === 'running'}
+                className="bg-dark-700 border border-dark-600 rounded px-2 py-1.5 text-xs text-dark-100 disabled:opacity-50"
+              >
+                <option value="">No environment</option>
+                {environments.map(env => (
+                  <option key={env.id} value={env.id}>{env.name}</option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] text-dark-400 uppercase tracking-wider">Delay (ms)</span>
+              <input
+                type="number"
+                min={0}
+                max={60_000}
+                value={delayMs}
+                onChange={e => setDelayMs(Math.max(0, Number(e.target.value) || 0))}
+                disabled={phase === 'running'}
+                className="w-24 bg-dark-700 border border-dark-600 rounded px-2 py-1.5 text-xs text-dark-100 disabled:opacity-50"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-xs text-dark-200 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={stopOnFailure}
+                onChange={e => setStopOnFailure(e.target.checked)}
+                disabled={phase === 'running'}
+                className="accent-accent-blue"
+              />
+              Stop on first failure
+            </label>
+            <div className="flex-1" />
+            {phase !== 'running' ? (
+              <button
+                onClick={handleStart}
+                disabled={total === 0}
+                className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-accent-blue hover:bg-accent-blue/80 disabled:opacity-50 rounded-lg cursor-pointer"
+              >
+                <Play size={14} />
+                {phase === 'finished' ? 'Run Again' : 'Start Run'}
+              </button>
+            ) : (
+              <button
+                onClick={handleStop}
+                className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-accent-red hover:bg-accent-red/80 rounded-lg cursor-pointer"
+              >
+                <Square size={14} />
+                Stop
+              </button>
+            )}
+          </div>
+
+          {/* Summary */}
+          <div className="bg-dark-900 border border-dark-600 rounded-lg p-3 mb-3">
+            <div className="grid grid-cols-4 gap-3 text-center">
+              <Stat label="Total" value={total} />
+              <Stat label="Passed" value={summary?.passed ?? rowCount(rows, r => r.status === 'done' && r.result.outcome === 'passed')} className="text-accent-green" />
+              <Stat label="Failed" value={summary?.failed ?? rowCount(rows, r => r.status === 'done' && r.result.outcome === 'failed')} className="text-accent-yellow" />
+              <Stat label="Errored" value={summary?.errored ?? rowCount(rows, r => r.status === 'done' && r.result.outcome === 'error')} className="text-accent-red" />
+            </div>
+            {summary && (
+              <div className="mt-3 pt-3 border-t border-dark-700 text-[11px] text-dark-400 text-center">
+                Completed {summary.completed}/{summary.total} in {(summary.durationMs / 1000).toFixed(2)}s
+              </div>
+            )}
+          </div>
+
+          {/* Rows */}
+          {total === 0 ? (
+            <div className="text-dark-500 text-xs text-center py-8">This collection has no requests.</div>
+          ) : (
+            <div className="flex flex-col border border-dark-600 rounded-lg overflow-hidden">
+              {collection.requests.map((req, i) => {
+                const row = rows[i] ?? { status: 'pending' };
+                const isExpanded = expanded.has(i);
+                const canExpand = row.status === 'done';
+                return (
+                  <div key={req.id} className="border-b border-dark-700 last:border-b-0">
+                    <button
+                      type="button"
+                      onClick={() => canExpand && toggleRow(i)}
+                      disabled={!canExpand}
+                      className={`w-full flex items-center gap-2 px-3 py-2 text-left ${canExpand ? 'hover:bg-dark-800/50 cursor-pointer' : 'cursor-default'}`}
+                    >
+                      <StatusIcon row={row} />
+                      <MethodBadge method={req.protocol === 'websocket' ? 'WS' : req.method} size="sm" />
+                      <span className="text-xs text-dark-200 truncate flex-1">{req.name || req.url || 'Untitled'}</span>
+                      {row.status === 'done' && (
+                        <span className="text-[11px] text-dark-400 flex-shrink-0">{row.durationMs}ms</span>
+                      )}
+                      {canExpand && (isExpanded ? <ChevronDown size={12} className="text-dark-500" /> : <ChevronRight size={12} className="text-dark-500" />)}
+                    </button>
+                    {isExpanded && row.status === 'done' && <RowDetail result={row.result} />}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusIcon({ row }: { row: RowState }) {
+  const size = 14;
+  if (row.status === 'pending') return <MinusCircle size={size} className="text-dark-500 flex-shrink-0" />;
+  if (row.status === 'running') return <Loader2 size={size} className="text-accent-blue animate-spin flex-shrink-0" />;
+  if (row.status === 'skipped') return <MinusCircle size={size} className="text-dark-400 flex-shrink-0" />;
+  switch (row.result.outcome) {
+    case 'passed':
+      return <Check size={size} className="text-accent-green flex-shrink-0" />;
+    case 'failed':
+      return <AlertTriangle size={size} className="text-accent-yellow flex-shrink-0" />;
+    case 'error':
+      return <XCircle size={size} className="text-accent-red flex-shrink-0" />;
+  }
+}
+
+function RowDetail({ result }: { result: ExecuteResult }) {
+  return (
+    <div className="px-3 pb-3 pt-1 bg-dark-900/60 text-xs space-y-2">
+      <div className="flex items-center gap-2 text-[11px] text-dark-400">
+        <span>Status: <span className="text-dark-200">{result.response.status} {result.response.statusText}</span></span>
+        <span>·</span>
+        <span>{result.response.time}ms</span>
+      </div>
+      {result.error && (
+        <div className="px-2 py-1.5 bg-accent-red/10 border border-accent-red/30 rounded text-accent-red text-[11px]">
+          {result.error}
+        </div>
+      )}
+      {result.testResults.length > 0 && (
+        <div>
+          <div className="text-[11px] text-dark-400 mb-1">Tests</div>
+          <ul className="space-y-0.5">
+            {result.testResults.map((t, j) => (
+              <li key={j} className="flex items-start gap-1.5 text-[11px]">
+                {t.passed ? (
+                  <Check size={11} className="text-accent-green mt-0.5 flex-shrink-0" />
+                ) : (
+                  <XCircle size={11} className="text-accent-red mt-0.5 flex-shrink-0" />
+                )}
+                <span className={t.passed ? 'text-dark-300' : 'text-accent-red'}>
+                  {t.name}
+                  {!t.passed && t.error && <span className="text-dark-400"> — {t.error}</span>}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {result.response.body && (
+        <div>
+          <div className="text-[11px] text-dark-400 mb-1">Response</div>
+          <pre className="bg-dark-900 border border-dark-600 rounded p-2 text-[11px] text-dark-200 font-mono max-h-32 overflow-auto whitespace-pre-wrap break-all">
+            {result.response.body.slice(0, 2000)}
+            {result.response.body.length > 2000 && '…'}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, className }: { label: string; value: number; className?: string }) {
+  return (
+    <div>
+      <div className={`text-lg font-semibold ${className ?? 'text-dark-100'}`}>{value}</div>
+      <div className="text-[10px] text-dark-400 uppercase tracking-wider">{label}</div>
+    </div>
+  );
+}
+
+function rowCount(rows: RowState[], pred: (r: RowState) => boolean): number {
+  return rows.reduce((n, r) => (pred(r) ? n + 1 : n), 0);
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,7 +30,11 @@ function stripScriptsFromCollection(collection: Collection): Collection {
   return { ...collection, requests: collection.requests.map(stripScripts) };
 }
 
-export function Sidebar() {
+interface SidebarProps {
+  onRunCollection?: (collectionId: string) => void;
+}
+
+export function Sidebar({ onRunCollection }: SidebarProps = {}) {
   const sidebarView = useAppStore(s => s.sidebarView);
   const setSidebarView = useAppStore(s => s.setSidebarView);
 
@@ -63,7 +67,7 @@ export function Sidebar() {
 
       {/* Content */}
       <div className="flex-1 overflow-auto">
-        {sidebarView === 'collections' && <CollectionsPanel />}
+        {sidebarView === 'collections' && <CollectionsPanel onRunCollection={onRunCollection} />}
         {sidebarView === 'history' && <HistoryPanel />}
         {sidebarView === 'environments' && <EnvironmentsPanel />}
       </div>
@@ -71,7 +75,7 @@ export function Sidebar() {
   );
 }
 
-function CollectionsPanel() {
+function CollectionsPanel({ onRunCollection }: { onRunCollection?: (id: string) => void }) {
   const collections = useAppStore(s => s.collections);
   const createCollection = useAppStore(s => s.createCollection);
   const [showImport, setShowImport] = useState(false);
@@ -190,13 +194,13 @@ function CollectionsPanel() {
           No collections yet. Click + to create one.
         </div>
       ) : (
-        collections.map(c => <CollectionItem key={c.id} collection={c} />)
+        collections.map(c => <CollectionItem key={c.id} collection={c} onRun={onRunCollection} />)
       )}
     </div>
   );
 }
 
-function CollectionItem({ collection }: { collection: Collection }) {
+function CollectionItem({ collection, onRun }: { collection: Collection; onRun?: (id: string) => void }) {
   const [expanded, setExpanded] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
   const deleteCollection = useAppStore(s => s.deleteCollection);
@@ -269,6 +273,16 @@ function CollectionItem({ collection }: { collection: Collection }) {
                 className="w-full text-left px-3 py-1.5 text-xs text-dark-200 hover:bg-dark-600 cursor-pointer"
               >
                 Export
+              </button>
+              <button
+                onClick={() => {
+                  onRun?.(collection.id);
+                  setShowMenu(false);
+                }}
+                disabled={collection.requests.length === 0}
+                className="w-full text-left px-3 py-1.5 text-xs text-dark-200 hover:bg-dark-600 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Run collection
               </button>
               <button
                 onClick={() => {

--- a/src/components/UrlBar.tsx
+++ b/src/components/UrlBar.tsx
@@ -1,9 +1,8 @@
 import { Send, Loader2, ShieldCheck, ShieldOff, Plug, Unplug } from 'lucide-react';
 import type { HttpMethod, RequestConfig } from '../types';
 import { useAppStore } from '../store';
-import { sendRequest, resolveRequestVariables, buildHeaders, buildBody } from '../utils/http';
 import { getMethodColor } from '../utils/http';
-import { runPreRequestScript, runTestScript } from '../utils/scriptEngine';
+import { executeRequestWithScripts } from '../utils/requestExecutor';
 import { isWebSocketUrl, connectWebSocket, disconnectWebSocket } from '../utils/websocket';
 
 const METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
@@ -62,140 +61,21 @@ export function UrlBar({ request }: Props) {
     setScriptLogs(request.id, []);
 
     try {
-      const variables = getActiveVariables();
-      const chainVars = getChainVariables();
-      let resolved = resolveRequestVariables(request, variables, chainVars);
-      let allLogs: import('../types').ScriptConsoleEntry[] = [];
-
-      // --- Pre-request script ---
-      if (request.preRequestScript?.trim()) {
-        const headers = buildHeaders(resolved.headers, resolved.auth);
-        const body = buildBody(resolved);
-        const bodyStr = body === null ? null : typeof body === 'string' ? body : null;
-
-        const preResult = runPreRequestScript(
-          request.preRequestScript,
-          resolved,
-          headers,
-          bodyStr,
-          variables,
-          chainVars,
-        );
-        allLogs = [...allLogs, ...preResult.logs];
-
-        if (preResult.error) {
-          setScriptLogs(request.id, allLogs);
-          setResponse(request.id, {
-            status: 0,
-            statusText: 'Script Error',
-            headers: {},
-            body: `Pre-request script error: ${preResult.error}`,
-            size: 0,
-            time: 0,
-            cookies: [],
-          });
-          setLoading(request.id, false);
-          return;
-        }
-
-        // Apply mutations from pre-request script.
-        // The script received fully-built headers (auth already baked in),
-        // so we neutralize header-based auth to prevent sendRequest from
-        // re-applying auth headers on top of whatever the script set.
-        // We preserve query-style API-key auth because sendRequest appends
-        // those to the URL — they aren't in the headers the script saw.
-        updateChainVariables(preResult.chain);
-        const isQueryApiKey = resolved.auth.type === 'api-key'
-          && resolved.auth.apiKey?.addTo === 'query';
-        resolved = {
-          ...resolved,
-          method: (preResult.request.method as RequestConfig['method']) || resolved.method,
-          url: preResult.request.url || resolved.url,
-          headers: Object.entries(preResult.request.headers).map(([key, value]) => ({
-            id: crypto.randomUUID(),
-            key,
-            value,
-            enabled: true,
-          })),
-          auth: isQueryApiKey ? resolved.auth : { type: 'none' },
-        };
-
-        // If the script changed the body, override with the raw string.
-        // Switch to body type 'text' so buildBody() reads .raw instead of
-        // rebuilding from structured fields (graphql, form-data, etc.).
-        // Also ensure Content-Type is preserved: the auto-header logic in
-        // sendRequest only fires for specific body types, so we inject the
-        // correct content-type into the resolved headers if the script
-        // didn't already set one.
-        if (preResult.request.body !== null && preResult.request.body !== bodyStr) {
-          const originalType = resolved.body.type;
-          resolved = {
-            ...resolved,
-            body: { ...resolved.body, type: 'text', raw: preResult.request.body },
-          };
-
-          // If the script's headers don't include Content-Type, carry over
-          // what sendRequest would have auto-set for the original body type.
-          const hasContentType = resolved.headers.some(
-            h => h.enabled && h.key.toLowerCase() === 'content-type',
-          );
-          if (!hasContentType) {
-            const autoType: Record<string, string> = {
-              json: 'application/json',
-              graphql: 'application/json',
-              xml: 'application/xml',
-              'x-www-form-urlencoded': 'application/x-www-form-urlencoded',
-            };
-            const ct = autoType[originalType];
-            if (ct) {
-              resolved = {
-                ...resolved,
-                headers: [
-                  ...resolved.headers,
-                  { id: crypto.randomUUID(), key: 'Content-Type', value: ct, enabled: true },
-                ],
-              };
-            }
-          }
-        }
-      }
-
-      const response = await sendRequest(resolved);
-      setResponse(request.id, response);
-      addToHistory(request, response);
-
-      // --- Post-response test script ---
-      if (request.testScript?.trim() && response.status !== 0) {
-        const latestChain = useAppStore.getState().chainVariables;
-        const testResult = runTestScript(request.testScript, resolved, response, latestChain);
-        allLogs = [...allLogs, ...testResult.logs];
-        setTestResults(request.id, testResult.tests);
-        updateChainVariables(testResult.chain);
-
-        if (testResult.error) {
-          allLogs.push({
-            type: 'error',
-            args: [`Test script error: ${testResult.error}`],
-            timestamp: Date.now(),
-          });
-        }
-      }
-
-      setScriptLogs(request.id, allLogs);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to send request';
-      const isProxyDown = message === 'Failed to fetch' || message.includes('NetworkError');
-      setResponse(request.id, {
-        status: 0,
-        statusText: 'Error',
-        headers: {},
-        body: isProxyDown
-          ? 'Could not reach the proxy server. Make sure it is running (npm run dev:server on port 3001).'
-          : message,
-        size: 0,
-        time: 0,
-        cookies: [],
+      const result = await executeRequestWithScripts(request, {
+        variables: getActiveVariables(),
+        chainVars: getChainVariables(),
       });
+
+      setResponse(request.id, result.response);
+      setScriptLogs(request.id, result.logs);
+      setTestResults(request.id, result.testResults);
+      if (Object.keys(result.chainVarUpdates).length > 0) {
+        updateChainVariables(result.chainVarUpdates);
+      }
+      // Only record a real network round-trip in history (skip script / network errors).
+      if (result.error === null) {
+        addToHistory(request, result.response);
+      }
     } finally {
       setLoading(request.id, false);
     }

--- a/src/utils/__tests__/collectionRunner.test.ts
+++ b/src/utils/__tests__/collectionRunner.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runCollection, type RunnerEvent } from '../collectionRunner';
+import { createDefaultRequest } from '../../types';
+import type { ExecuteResult } from '../requestExecutor';
+import type { ResponseData } from '../../types';
+
+vi.mock('../requestExecutor', () => ({
+  executeRequestWithScripts: vi.fn(),
+}));
+
+import { executeRequestWithScripts } from '../requestExecutor';
+const mockExec = vi.mocked(executeRequestWithScripts);
+
+function okResult(overrides: Partial<ExecuteResult> = {}): ExecuteResult {
+  const response: ResponseData = {
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    body: '{}',
+    size: 2,
+    time: 10,
+    cookies: [],
+  };
+  return {
+    resolvedRequest: createDefaultRequest(),
+    response,
+    testResults: [],
+    chainVarUpdates: {},
+    logs: [],
+    error: null,
+    outcome: 'passed',
+    ...overrides,
+  };
+}
+
+function collect(requests = 3) {
+  return Array.from({ length: requests }, (_, i) =>
+    createDefaultRequest({ name: `req-${i}`, url: `https://api.test/${i}` })
+  );
+}
+
+beforeEach(() => {
+  mockExec.mockReset();
+});
+
+// ─── Empty collection ────────────────────────────────────────────────────────
+
+describe('runCollection — empty', () => {
+  it('emits start + done only, zero totals', async () => {
+    const events: RunnerEvent[] = [];
+    await runCollection({
+      requests: [],
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars: () => {},
+      stopOnFailure: false,
+      delayMs: 0,
+      signal: new AbortController().signal,
+      onEvent: e => events.push(e),
+    });
+    expect(events[0]).toEqual({ type: 'start', total: 0 });
+    expect(events[events.length - 1].type).toBe('done');
+    const done = events.at(-1) as Extract<RunnerEvent, { type: 'done' }>;
+    expect(done.summary.total).toBe(0);
+    expect(done.summary.completed).toBe(0);
+  });
+});
+
+// ─── Happy path ──────────────────────────────────────────────────────────────
+
+describe('runCollection — happy path', () => {
+  it('emits start + per-request start/complete + done for all passing', async () => {
+    mockExec.mockResolvedValue(okResult());
+    const events: RunnerEvent[] = [];
+    await runCollection({
+      requests: collect(3),
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars: () => {},
+      stopOnFailure: false,
+      delayMs: 0,
+      signal: new AbortController().signal,
+      onEvent: e => events.push(e),
+    });
+
+    const types = events.map(e => e.type);
+    expect(types).toEqual([
+      'start',
+      'request-start', 'request-complete',
+      'request-start', 'request-complete',
+      'request-start', 'request-complete',
+      'done',
+    ]);
+    const done = events.at(-1) as Extract<RunnerEvent, { type: 'done' }>;
+    expect(done.summary).toMatchObject({ total: 3, completed: 3, passed: 3, failed: 0, errored: 0 });
+  });
+});
+
+// ─── Outcome counting ───────────────────────────────────────────────────────
+
+describe('runCollection — outcome counting', () => {
+  it('tallies passed/failed/errored correctly', async () => {
+    mockExec
+      .mockResolvedValueOnce(okResult({ outcome: 'passed' }))
+      .mockResolvedValueOnce(okResult({ outcome: 'failed' }))
+      .mockResolvedValueOnce(okResult({ outcome: 'error' }));
+
+    const events: RunnerEvent[] = [];
+    await runCollection({
+      requests: collect(3),
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars: () => {},
+      stopOnFailure: false,
+      delayMs: 0,
+      signal: new AbortController().signal,
+      onEvent: e => events.push(e),
+    });
+
+    const done = events.at(-1) as Extract<RunnerEvent, { type: 'done' }>;
+    expect(done.summary).toMatchObject({ passed: 1, failed: 1, errored: 1, completed: 3 });
+  });
+});
+
+// ─── Stop on failure ────────────────────────────────────────────────────────
+
+describe('runCollection — stopOnFailure', () => {
+  it('skips the rest after a failure when enabled', async () => {
+    mockExec
+      .mockResolvedValueOnce(okResult({ outcome: 'passed' }))
+      .mockResolvedValueOnce(okResult({ outcome: 'failed' }));
+
+    const events: RunnerEvent[] = [];
+    await runCollection({
+      requests: collect(3),
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars: () => {},
+      stopOnFailure: true,
+      delayMs: 0,
+      signal: new AbortController().signal,
+      onEvent: e => events.push(e),
+    });
+
+    // Only two executes ran; the 3rd became a skip event
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    const skip = events.find(e => e.type === 'request-skipped');
+    expect(skip).toEqual({ type: 'request-skipped', index: 2, reason: 'stop-on-failure' });
+  });
+
+  it('skips the rest after an error when enabled', async () => {
+    mockExec
+      .mockResolvedValueOnce(okResult({ outcome: 'error' }))
+      .mockResolvedValueOnce(okResult()); // should never be reached
+
+    const events: RunnerEvent[] = [];
+    await runCollection({
+      requests: collect(2),
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars: () => {},
+      stopOnFailure: true,
+      delayMs: 0,
+      signal: new AbortController().signal,
+      onEvent: e => events.push(e),
+    });
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    expect(events.some(e => e.type === 'request-skipped' && e.reason === 'stop-on-failure')).toBe(true);
+  });
+
+  it('does NOT stop when disabled (default)', async () => {
+    mockExec
+      .mockResolvedValueOnce(okResult({ outcome: 'failed' }))
+      .mockResolvedValueOnce(okResult({ outcome: 'passed' }));
+
+    await runCollection({
+      requests: collect(2),
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars: () => {},
+      stopOnFailure: false,
+      delayMs: 0,
+      signal: new AbortController().signal,
+      onEvent: () => {},
+    });
+    expect(mockExec).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── Abort ──────────────────────────────────────────────────────────────────
+
+describe('runCollection — abort', () => {
+  it('skips remaining requests after the signal aborts', async () => {
+    const controller = new AbortController();
+    mockExec
+      .mockResolvedValueOnce(okResult())
+      .mockImplementationOnce(async () => {
+        controller.abort();
+        return okResult();
+      });
+
+    const events: RunnerEvent[] = [];
+    await runCollection({
+      requests: collect(4),
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars: () => {},
+      stopOnFailure: false,
+      delayMs: 0,
+      signal: controller.signal,
+      onEvent: e => events.push(e),
+    });
+
+    // Only 2 ran; 2 and 3 are skipped with 'aborted'
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    const skips = events.filter(e => e.type === 'request-skipped');
+    expect(skips).toHaveLength(2);
+    expect(skips.every(s => s.type === 'request-skipped' && s.reason === 'aborted')).toBe(true);
+  });
+});
+
+// ─── Chain variables ────────────────────────────────────────────────────────
+
+describe('runCollection — chain variables', () => {
+  it('reads fresh chain vars before each request and pipes updates back', async () => {
+    const chainStore: Record<string, string> = {};
+    const seenChains: Record<string, string>[] = [];
+
+    mockExec.mockImplementation(async (_req, ctx) => {
+      seenChains.push({ ...ctx.chainVars });
+      return okResult({ chainVarUpdates: { counter: String(seenChains.length) } });
+    });
+
+    await runCollection({
+      requests: collect(3),
+      variables: {},
+      getChainVars: () => ({ ...chainStore }),
+      onChainVars: updates => Object.assign(chainStore, updates),
+      stopOnFailure: false,
+      delayMs: 0,
+      signal: new AbortController().signal,
+      onEvent: () => {},
+    });
+
+    // Each execution saw the chain state from the prior one's update
+    expect(seenChains[0]).toEqual({});
+    expect(seenChains[1]).toEqual({ counter: '1' });
+    expect(seenChains[2]).toEqual({ counter: '2' });
+    expect(chainStore).toEqual({ counter: '3' });
+  });
+
+  it('does not call onChainVars when there are no updates', async () => {
+    mockExec.mockResolvedValue(okResult({ chainVarUpdates: {} }));
+    const onChainVars = vi.fn();
+    await runCollection({
+      requests: collect(2),
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars,
+      stopOnFailure: false,
+      delayMs: 0,
+      signal: new AbortController().signal,
+      onEvent: () => {},
+    });
+    expect(onChainVars).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Delay ──────────────────────────────────────────────────────────────────
+
+describe('runCollection — delay', () => {
+  it('waits delayMs between successful requests', async () => {
+    vi.useFakeTimers();
+    mockExec.mockResolvedValue(okResult());
+    const completedAt: number[] = [];
+    mockExec.mockImplementation(async () => {
+      completedAt.push(Date.now());
+      return okResult();
+    });
+
+    const run = runCollection({
+      requests: collect(2),
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars: () => {},
+      stopOnFailure: false,
+      delayMs: 500,
+      signal: new AbortController().signal,
+      onEvent: () => {},
+    });
+
+    // Let the first execute run to completion, then advance past the delay
+    await vi.runAllTimersAsync();
+    await run;
+
+    expect(completedAt[1] - completedAt[0]).toBeGreaterThanOrEqual(500);
+    vi.useRealTimers();
+  });
+
+  it('does not delay after the final request', async () => {
+    mockExec.mockResolvedValue(okResult());
+    const start = Date.now();
+    await runCollection({
+      requests: collect(1),
+      variables: {},
+      getChainVars: () => ({}),
+      onChainVars: () => {},
+      stopOnFailure: false,
+      delayMs: 10_000, // if this were applied, the test would time out
+      signal: new AbortController().signal,
+      onEvent: () => {},
+    });
+    expect(Date.now() - start).toBeLessThan(1_000);
+  });
+});

--- a/src/utils/__tests__/requestExecutor.test.ts
+++ b/src/utils/__tests__/requestExecutor.test.ts
@@ -91,13 +91,43 @@ describe('executeRequestWithScripts — test scripts', () => {
     expect(result.testResults[1].passed).toBe(false);
   });
 
-  it('does NOT flag 4xx/5xx as failure on its own (tests are authoritative)', async () => {
+  it('flags 5xx as failed when no test script is defined', async () => {
     mockSend.mockResolvedValueOnce({ ...okResponse(), status: 500, statusText: 'Internal Server Error' });
     const result = await executeRequestWithScripts(
       createDefaultRequest({ url: 'https://api.test/x' }),
       { variables: {}, chainVars: {} },
     );
-    expect(result.outcome).toBe('passed'); // no tests, no assertions = no failure
+    expect(result.outcome).toBe('failed');
+  });
+
+  it('flags 4xx as failed when no test script is defined', async () => {
+    mockSend.mockResolvedValueOnce({ ...okResponse(), status: 404, statusText: 'Not Found' });
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({ url: 'https://api.test/x' }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('failed');
+  });
+
+  it('lets a test script override status-based failure (user expects the 404)', async () => {
+    mockSend.mockResolvedValueOnce({ ...okResponse(), status: 404, statusText: 'Not Found' });
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({
+        url: 'https://api.test/x',
+        testScript: 'curlit.test("404 is expected", () => { if (curlit.response.status !== 404) throw new Error("nope"); });',
+      }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('passed');
+  });
+
+  it('still treats 3xx as passed (not a failure)', async () => {
+    mockSend.mockResolvedValueOnce({ ...okResponse(), status: 301, statusText: 'Moved Permanently' });
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({ url: 'https://api.test/x' }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('passed');
   });
 });
 
@@ -170,6 +200,39 @@ describe('executeRequestWithScripts — error paths', () => {
       { variables: {}, chainVars: {} },
     );
     expect(result.response.body).toBe('Gateway timeout');
+  });
+
+  it('treats a status-0 response from the proxy as an error (e.g. SSL or target-unreachable)', async () => {
+    mockSend.mockResolvedValueOnce({
+      status: 0,
+      statusText: 'Error',
+      headers: {},
+      body: 'unable to verify the first certificate',
+      size: 0,
+      time: 14,
+      cookies: [],
+    });
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({ url: 'https://untrusted.test/x' }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('error');
+    expect(result.error).toContain('unable to verify');
+  });
+
+  it('does NOT run test scripts when status is 0', async () => {
+    mockSend.mockResolvedValueOnce({
+      status: 0, statusText: 'Error', headers: {}, body: 'boom', size: 0, time: 5, cookies: [],
+    });
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({
+        url: 'https://api.test/x',
+        testScript: 'curlit.test("should not run", () => {});',
+      }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.testResults).toEqual([]);
+    expect(result.outcome).toBe('error');
   });
 });
 

--- a/src/utils/__tests__/requestExecutor.test.ts
+++ b/src/utils/__tests__/requestExecutor.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { executeRequestWithScripts } from '../requestExecutor';
+import { createDefaultRequest } from '../../types';
+import type { ResponseData } from '../../types';
+
+vi.mock('../http', async () => {
+  const actual = await vi.importActual<typeof import('../http')>('../http');
+  return {
+    ...actual,
+    sendRequest: vi.fn(),
+  };
+});
+
+import { sendRequest } from '../http';
+const mockSend = vi.mocked(sendRequest);
+
+function okResponse(body = '{}'): ResponseData {
+  return {
+    status: 200,
+    statusText: 'OK',
+    headers: { 'content-type': 'application/json' },
+    body,
+    size: body.length,
+    time: 42,
+    cookies: [],
+  };
+}
+
+beforeEach(() => {
+  mockSend.mockReset();
+});
+
+// ─── Happy path ──────────────────────────────────────────────────────────────
+
+describe('executeRequestWithScripts — happy path', () => {
+  it('returns passed outcome with no scripts', async () => {
+    mockSend.mockResolvedValueOnce(okResponse());
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({ url: 'https://api.test/x' }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('passed');
+    expect(result.error).toBeNull();
+    expect(result.response.status).toBe(200);
+    expect(result.testResults).toEqual([]);
+  });
+
+  it('substitutes env variables before sending', async () => {
+    mockSend.mockResolvedValueOnce(okResponse());
+    await executeRequestWithScripts(
+      createDefaultRequest({ url: '{{base}}/items' }),
+      { variables: { base: 'https://api.test' }, chainVars: {} },
+    );
+    expect(mockSend.mock.calls[0][0].url).toBe('https://api.test/items');
+  });
+});
+
+// ─── Test script outcomes ───────────────────────────────────────────────────
+
+describe('executeRequestWithScripts — test scripts', () => {
+  it('reports passed when all tests pass', async () => {
+    mockSend.mockResolvedValueOnce(okResponse('{"ok":true}'));
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({
+        url: 'https://api.test/x',
+        testScript: 'curlit.test("status is 200", () => { if (curlit.response.status !== 200) throw new Error("nope"); });',
+      }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('passed');
+    expect(result.testResults).toHaveLength(1);
+    expect(result.testResults[0].passed).toBe(true);
+  });
+
+  it('reports failed when any test assertion fails', async () => {
+    mockSend.mockResolvedValueOnce(okResponse('{"ok":true}'));
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({
+        url: 'https://api.test/x',
+        testScript: `
+          curlit.test("a passes", () => {});
+          curlit.test("b fails", () => { throw new Error("boom"); });
+        `,
+      }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('failed');
+    expect(result.error).toBeNull();
+    expect(result.testResults).toHaveLength(2);
+    expect(result.testResults[0].passed).toBe(true);
+    expect(result.testResults[1].passed).toBe(false);
+  });
+
+  it('does NOT flag 4xx/5xx as failure on its own (tests are authoritative)', async () => {
+    mockSend.mockResolvedValueOnce({ ...okResponse(), status: 500, statusText: 'Internal Server Error' });
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({ url: 'https://api.test/x' }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('passed'); // no tests, no assertions = no failure
+  });
+});
+
+// ─── Chain variables ─────────────────────────────────────────────────────────
+
+describe('executeRequestWithScripts — chain variables', () => {
+  it('collects chain var updates from the test script', async () => {
+    mockSend.mockResolvedValueOnce(okResponse('{"token":"abc"}'));
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({
+        url: 'https://api.test/login',
+        testScript: 'curlit.chain.authToken = JSON.parse(curlit.response.body).token;',
+      }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.chainVarUpdates.authToken).toBe('abc');
+  });
+
+  it('passes incoming chain vars to pre-request and test scripts', async () => {
+    mockSend.mockResolvedValueOnce(okResponse());
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({
+        url: 'https://api.test/x',
+        preRequestScript: 'curlit.request.headers["X-Saw"] = curlit.chain.existing;',
+      }),
+      { variables: {}, chainVars: { existing: 'hello' } },
+    );
+    expect(result.outcome).toBe('passed');
+    // Header was applied before send
+    const call = mockSend.mock.calls[0][0];
+    const sawHeader = call.headers.find(h => h.key === 'X-Saw');
+    expect(sawHeader?.value).toBe('hello');
+  });
+});
+
+// ─── Error paths ─────────────────────────────────────────────────────────────
+
+describe('executeRequestWithScripts — error paths', () => {
+  it('returns error outcome on pre-request script error and does NOT send', async () => {
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({
+        url: 'https://api.test/x',
+        preRequestScript: 'throw new Error("bad setup");',
+      }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('error');
+    expect(result.error).toMatch(/bad setup/);
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(result.response.status).toBe(0);
+    expect(result.response.statusText).toBe('Script Error');
+  });
+
+  it('returns error outcome on network failure', async () => {
+    mockSend.mockRejectedValueOnce(new Error('Failed to fetch'));
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({ url: 'https://api.test/x' }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.outcome).toBe('error');
+    expect(result.error).toBe('Failed to fetch');
+    expect(result.response.status).toBe(0);
+    expect(result.response.body).toContain('proxy server');
+  });
+
+  it('surfaces generic network error messages in the response body', async () => {
+    mockSend.mockRejectedValueOnce(new Error('Gateway timeout'));
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({ url: 'https://api.test/x' }),
+      { variables: {}, chainVars: {} },
+    );
+    expect(result.response.body).toBe('Gateway timeout');
+  });
+});
+
+// ─── Logs ────────────────────────────────────────────────────────────────────
+
+describe('executeRequestWithScripts — logs', () => {
+  it('accumulates logs from pre-request and test scripts in order', async () => {
+    mockSend.mockResolvedValueOnce(okResponse());
+    const result = await executeRequestWithScripts(
+      createDefaultRequest({
+        url: 'https://api.test/x',
+        preRequestScript: 'console.log("pre");',
+        testScript: 'console.log("post");',
+      }),
+      { variables: {}, chainVars: {} },
+    );
+    const messages = result.logs.map(l => l.args[0]);
+    expect(messages).toEqual(['pre', 'post']);
+  });
+});

--- a/src/utils/collectionRunner.ts
+++ b/src/utils/collectionRunner.ts
@@ -1,0 +1,119 @@
+import type { RequestConfig } from '../types';
+import { executeRequestWithScripts, type ExecuteResult } from './requestExecutor';
+
+export interface RunnerSummary {
+  total: number;
+  completed: number;
+  passed: number;
+  failed: number;
+  errored: number;
+  durationMs: number;
+}
+
+export type RunnerEvent =
+  | { type: 'start'; total: number }
+  | { type: 'request-start'; index: number }
+  | { type: 'request-complete'; index: number; result: ExecuteResult; durationMs: number }
+  | { type: 'request-skipped'; index: number; reason: 'aborted' | 'stop-on-failure' }
+  | { type: 'done'; summary: RunnerSummary };
+
+export interface RunnerOptions {
+  requests: RequestConfig[];
+  /** Env vars for variable substitution — captured once at run start. */
+  variables: Record<string, string>;
+  /** Live read of chain vars — called before each request so prior updates flow. */
+  getChainVars: () => Record<string, string>;
+  /** Called after each request with the chain var updates to merge into the store. */
+  onChainVars: (updates: Record<string, string>) => void;
+  stopOnFailure: boolean;
+  delayMs: number;
+  signal: AbortSignal;
+  onEvent: (event: RunnerEvent) => void;
+}
+
+/**
+ * Cancellable sleep that resolves early when the signal aborts (so Stop is snappy).
+ */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal.aborted) return Promise.resolve();
+  return new Promise(resolve => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Drive a sequential run over a collection's requests. Emits events so the UI
+ * can render row state; no store writes happen here — the caller wires chain
+ * variable updates through the store via `onChainVars`.
+ */
+export async function runCollection(options: RunnerOptions): Promise<void> {
+  const { requests, variables, getChainVars, onChainVars, stopOnFailure, delayMs, signal, onEvent } = options;
+  const startedAt = Date.now();
+  const summary: RunnerSummary = {
+    total: requests.length,
+    completed: 0,
+    passed: 0,
+    failed: 0,
+    errored: 0,
+    durationMs: 0,
+  };
+
+  onEvent({ type: 'start', total: requests.length });
+
+  let shouldSkipRest: 'aborted' | 'stop-on-failure' | null = null;
+
+  for (let i = 0; i < requests.length; i++) {
+    if (signal.aborted) shouldSkipRest = 'aborted';
+
+    if (shouldSkipRest) {
+      onEvent({ type: 'request-skipped', index: i, reason: shouldSkipRest });
+      continue;
+    }
+
+    onEvent({ type: 'request-start', index: i });
+    const reqStartedAt = Date.now();
+
+    const result = await executeRequestWithScripts(requests[i], {
+      variables,
+      chainVars: getChainVars(),
+    });
+
+    const durationMs = Date.now() - reqStartedAt;
+    summary.completed++;
+    if (result.outcome === 'passed') summary.passed++;
+    else if (result.outcome === 'failed') summary.failed++;
+    else summary.errored++;
+
+    if (Object.keys(result.chainVarUpdates).length > 0) {
+      onChainVars(result.chainVarUpdates);
+    }
+
+    onEvent({ type: 'request-complete', index: i, result, durationMs });
+
+    if (signal.aborted) {
+      shouldSkipRest = 'aborted';
+      continue;
+    }
+
+    if (stopOnFailure && result.outcome !== 'passed') {
+      shouldSkipRest = 'stop-on-failure';
+      continue;
+    }
+
+    if (i < requests.length - 1 && delayMs > 0) {
+      await sleep(delayMs, signal);
+      if (signal.aborted) shouldSkipRest = 'aborted';
+    }
+  }
+
+  summary.durationMs = Date.now() - startedAt;
+  onEvent({ type: 'done', summary });
+}

--- a/src/utils/requestExecutor.ts
+++ b/src/utils/requestExecutor.ts
@@ -153,12 +153,30 @@ export async function executeRequestWithScripts(
     };
   }
 
+  // Status 0 from the proxy means the target request failed at the network /
+  // SSL / validation layer — the proxy itself returned 200 but wrapped a
+  // failure in the JSON payload (e.g. `{ status: 0, statusText: 'Error',
+  // body: 'unable to verify the first certificate' }`). Treat that the same
+  // as a thrown network error: skip test scripts and classify as 'error'.
+  if (response.status === 0) {
+    return {
+      resolvedRequest: resolved,
+      response,
+      testResults: [],
+      chainVarUpdates,
+      logs,
+      error: response.body || response.statusText || 'Network error',
+      outcome: 'error',
+    };
+  }
+
   // --- Post-response test script ---
   let testResults: TestResult[] = [];
-  if (request.testScript?.trim() && response.status !== 0) {
+  const hasTestScript = !!request.testScript?.trim();
+  if (hasTestScript) {
     // Merge in any chain-var updates from pre-request so tests see them.
     const chainForTests = { ...ctx.chainVars, ...chainVarUpdates };
-    const testResult = runTestScript(request.testScript, resolved, response, chainForTests);
+    const testResult = runTestScript(request.testScript!, resolved, response, chainForTests);
     logs.push(...testResult.logs);
     testResults = testResult.tests;
     Object.assign(chainVarUpdates, testResult.chain);
@@ -172,8 +190,17 @@ export async function executeRequestWithScripts(
     }
   }
 
-  const anyTestFailed = testResults.some(t => !t.passed);
-  const outcome: ExecuteOutcome = anyTestFailed ? 'failed' : 'passed';
+  // Outcome rules:
+  //  - If tests exist, they are authoritative (any failing test = failed).
+  //  - Otherwise, fall back to HTTP status: 4xx/5xx without a test script
+  //    counts as failed so collection-runner rows don't green-check an error
+  //    response the user hasn't explicitly blessed.
+  let outcome: ExecuteOutcome;
+  if (hasTestScript) {
+    outcome = testResults.some(t => !t.passed) ? 'failed' : 'passed';
+  } else {
+    outcome = response.status >= 400 ? 'failed' : 'passed';
+  }
 
   return {
     resolvedRequest: resolved,

--- a/src/utils/requestExecutor.ts
+++ b/src/utils/requestExecutor.ts
@@ -1,0 +1,187 @@
+import type { RequestConfig, ResponseData, TestResult, ScriptConsoleEntry } from '../types';
+import { sendRequest, resolveRequestVariables, buildHeaders, buildBody } from './http';
+import { runPreRequestScript, runTestScript } from './scriptEngine';
+
+export interface ExecuteContext {
+  /** Environment variables available via {{ }} substitution. */
+  variables: Record<string, string>;
+  /** Chain variables snapshot (updated by prior test scripts). */
+  chainVars: Record<string, string>;
+}
+
+export type ExecuteOutcome = 'passed' | 'failed' | 'error';
+
+export interface ExecuteResult {
+  resolvedRequest: RequestConfig;
+  /** Always present; status 0 + statusText: 'Error' | 'Script Error' on failure paths. */
+  response: ResponseData;
+  testResults: TestResult[];
+  chainVarUpdates: Record<string, string>;
+  logs: ScriptConsoleEntry[];
+  error: string | null;
+  outcome: ExecuteOutcome;
+}
+
+function errorResponse(statusText: string, body: string): ResponseData {
+  return { status: 0, statusText, headers: {}, body, size: 0, time: 0, cookies: [] };
+}
+
+/**
+ * Run the full send-a-request sequence: variable substitution → optional
+ * pre-request script → network send → optional test script. Returns all
+ * artifacts so the caller can decide where to persist them (tab store, runner
+ * state, history, etc.) — this function never touches the store directly.
+ *
+ * Extracted from UrlBar.handleSend so the Collection Runner can reuse it per
+ * iteration without duplicating 150 lines of script-handling nuance.
+ */
+export async function executeRequestWithScripts(
+  request: RequestConfig,
+  ctx: ExecuteContext,
+): Promise<ExecuteResult> {
+  const logs: ScriptConsoleEntry[] = [];
+  const chainVarUpdates: Record<string, string> = {};
+
+  let resolved = resolveRequestVariables(request, ctx.variables, ctx.chainVars);
+
+  // --- Pre-request script ---
+  if (request.preRequestScript?.trim()) {
+    const headers = buildHeaders(resolved.headers, resolved.auth);
+    const body = buildBody(resolved);
+    const bodyStr = body === null ? null : typeof body === 'string' ? body : null;
+
+    const preResult = runPreRequestScript(
+      request.preRequestScript,
+      resolved,
+      headers,
+      bodyStr,
+      ctx.variables,
+      ctx.chainVars,
+    );
+    logs.push(...preResult.logs);
+
+    if (preResult.error) {
+      return {
+        resolvedRequest: resolved,
+        response: errorResponse('Script Error', `Pre-request script error: ${preResult.error}`),
+        testResults: [],
+        chainVarUpdates: preResult.chain,
+        logs,
+        error: preResult.error,
+        outcome: 'error',
+      };
+    }
+
+    Object.assign(chainVarUpdates, preResult.chain);
+
+    // Apply mutations from pre-request script. The script received fully-built
+    // headers (auth already baked in), so we neutralize header-based auth to
+    // prevent sendRequest from re-applying auth on top of what the script set.
+    // Query-style API-key auth is preserved because sendRequest appends those
+    // to the URL — they aren't in the headers the script saw.
+    const isQueryApiKey =
+      resolved.auth.type === 'api-key' && resolved.auth.apiKey?.addTo === 'query';
+    resolved = {
+      ...resolved,
+      method: (preResult.request.method as RequestConfig['method']) || resolved.method,
+      url: preResult.request.url || resolved.url,
+      headers: Object.entries(preResult.request.headers).map(([key, value]) => ({
+        id: crypto.randomUUID(),
+        key,
+        value,
+        enabled: true,
+      })),
+      auth: isQueryApiKey ? resolved.auth : { type: 'none' },
+    };
+
+    // If the script changed the body, override with the raw string and switch
+    // body type to 'text' so buildBody() reads .raw instead of rebuilding from
+    // structured fields (graphql, form-data, etc.). Preserve Content-Type by
+    // carrying over what sendRequest would have auto-set for the original body
+    // type, unless the script already set one.
+    if (preResult.request.body !== null && preResult.request.body !== bodyStr) {
+      const originalType = resolved.body.type;
+      resolved = {
+        ...resolved,
+        body: { ...resolved.body, type: 'text', raw: preResult.request.body },
+      };
+
+      const hasContentType = resolved.headers.some(
+        h => h.enabled && h.key.toLowerCase() === 'content-type',
+      );
+      if (!hasContentType) {
+        const autoType: Record<string, string> = {
+          json: 'application/json',
+          graphql: 'application/json',
+          xml: 'application/xml',
+          'x-www-form-urlencoded': 'application/x-www-form-urlencoded',
+        };
+        const ct = autoType[originalType];
+        if (ct) {
+          resolved = {
+            ...resolved,
+            headers: [
+              ...resolved.headers,
+              { id: crypto.randomUUID(), key: 'Content-Type', value: ct, enabled: true },
+            ],
+          };
+        }
+      }
+    }
+  }
+
+  // --- Send ---
+  let response: ResponseData;
+  try {
+    response = await sendRequest(resolved);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to send request';
+    const isProxyDown = message === 'Failed to fetch' || message.includes('NetworkError');
+    return {
+      resolvedRequest: resolved,
+      response: errorResponse(
+        'Error',
+        isProxyDown
+          ? 'Could not reach the proxy server. Make sure it is running (npm run dev:server on port 3001).'
+          : message,
+      ),
+      testResults: [],
+      chainVarUpdates,
+      logs,
+      error: message,
+      outcome: 'error',
+    };
+  }
+
+  // --- Post-response test script ---
+  let testResults: TestResult[] = [];
+  if (request.testScript?.trim() && response.status !== 0) {
+    // Merge in any chain-var updates from pre-request so tests see them.
+    const chainForTests = { ...ctx.chainVars, ...chainVarUpdates };
+    const testResult = runTestScript(request.testScript, resolved, response, chainForTests);
+    logs.push(...testResult.logs);
+    testResults = testResult.tests;
+    Object.assign(chainVarUpdates, testResult.chain);
+
+    if (testResult.error) {
+      logs.push({
+        type: 'error',
+        args: [`Test script error: ${testResult.error}`],
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  const anyTestFailed = testResults.some(t => !t.passed);
+  const outcome: ExecuteOutcome = anyTestFailed ? 'failed' : 'passed';
+
+  return {
+    resolvedRequest: resolved,
+    response,
+    testResults,
+    chainVarUpdates,
+    logs,
+    error: null,
+    outcome,
+  };
+}


### PR DESCRIPTION
## Summary
- New **Run collection** entry in each collection's `...` menu opens a runner modal that executes every request sequentially with a live per-row status (pending → running → passed / failed / errored / skipped), expandable rows with response body + test results, and a summary card at the top.
- Options: **environment override** (defaults to active env), **per-request delay** (ms), **stop on first failure**. Start / Stop use `AbortSignal` so in-flight delays and pending requests cancel promptly.
- Chain variables set by test scripts flow through the existing store mechanism, so setup → call → cleanup chains work naturally inside a run.
- Implements the `v1.4` roadmap item `Collection runner -- execute all requests in a collection sequentially`.

## Failure taxonomy (matches Postman / Insomnia)
- **passed** — request completed AND (no tests OR all tests passed)
- **failed** — one or more assertions in `testScript` failed
- **errored** — network or pre-request-script crash
- A 4xx/5xx on its own is *not* a failure — user tests are authoritative.

## Prerequisite refactor
Extracted the 147-line `UrlBar.handleSend` into **`src/utils/requestExecutor.ts`** as `executeRequestWithScripts`. The Send button and the runner share the exact same pre-request / test-script handling — no drift risk. `UrlBar` is now a thin store-side-effects wrapper around the helper; existing `UrlBar` tests still pass unchanged.

## Test plan
- [x] 11 unit tests for `requestExecutor` (happy path, test script outcomes, 4xx/5xx not failed, chain vars in/out, pre-request-script errors, network errors, log accumulation).
- [x] 11 unit tests for `collectionRunner` (event ordering, empty, counts, stop-on-failure, abort mid-run, chain vars flowing between requests, delay respected and skipped after last).
- [x] 2 Playwright e2e tests (`e2e/collection-runner.spec.ts`): happy path against httpbin.org with 2 requests → `2 passed`; empty collection → Run item disabled.
- [x] Full suite: `npm test -- --run` → **454 passed** (up from 432).
- [x] Existing `UrlBar.test.tsx` still green after the refactor.